### PR TITLE
Add console display options for Python runs

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -148,11 +148,14 @@ export interface PythonExecutionLogEntry {
   message: string;
 }
 
+export type PythonConsoleBehavior = 'in-app' | 'windows-terminal' | 'hidden';
+
 export interface PythonRunRequestPayload {
   nodeId: string;
   code: string;
   environment: PythonEnvironmentConfig;
   consoleTheme: 'light' | 'dark';
+  consoleBehavior: PythonConsoleBehavior;
 }
 
 export interface Node {


### PR DESCRIPTION
## Summary
- add a console display selector that persists per user and exposes in-app, hidden, or Windows Terminal execution modes
- update Python run payloads and manager to pass the selected console behavior through to the Electron backend
- launch Windows Terminal for interactive runs on Windows and skip the in-app console window when hidden

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd3bed45148332a690f3b8f91fb1d6