### PR TITLE
Make Python execution panel resizable and streamlined

### DIFF
--- a/components/PromptEditor.tsx
+++ b/components/PromptEditor.tsx
@@ -52,6 +52,21 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
     addLog,
   });
   
+  const pythonPanelMinHeight = 180;
+  const [pythonPanelHeight, setPythonPanelHeight] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('docforge.python.panelHeight');
+      if (stored) {
+        const parsed = parseInt(stored, 10);
+        if (!Number.isNaN(parsed)) {
+          const maxHeight = Math.max(pythonPanelMinHeight, window.innerHeight - 220);
+          return Math.min(Math.max(parsed, pythonPanelMinHeight), maxHeight);
+        }
+      }
+    }
+    return 260;
+  });
+
   const isResizing = useRef(false);
   const splitContainerRef = useRef<HTMLDivElement>(null);
   const acceptButtonRef = useRef<HTMLButtonElement>(null);
@@ -63,6 +78,21 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
   const isInitialMount = useRef(true);
   const prevDocumentIdRef = useRef<string | null>(null);
   const prevDocumentContentRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('docforge.python.panelHeight', String(Math.round(pythonPanelHeight)));
+  }, [pythonPanelHeight]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleWindowResize = () => {
+      const maxHeight = Math.max(pythonPanelMinHeight, window.innerHeight - 220);
+      setPythonPanelHeight((current) => Math.min(Math.max(current, pythonPanelMinHeight), maxHeight));
+    };
+    window.addEventListener('resize', handleWindowResize);
+    return () => window.removeEventListener('resize', handleWindowResize);
+  }, [pythonPanelMinHeight]);
 
   // Keep local editor state in sync with document updates without clobbering unsaved edits.
   useEffect(() => {
@@ -326,6 +356,51 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
     ...settings.pythonDefaults,
     workingDirectory: settings.pythonWorkingDirectory ?? settings.pythonDefaults.workingDirectory ?? null,
   }), [settings.pythonDefaults, settings.pythonWorkingDirectory]);
+
+  const handlePythonPanelResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    const startY = event.clientY;
+    const startHeight = pythonPanelHeight;
+    const pointerId = event.pointerId;
+    const target = event.currentTarget;
+
+    const getMaxHeight = () => {
+      if (typeof window === 'undefined') return startHeight;
+      return Math.max(pythonPanelMinHeight, window.innerHeight - 220);
+    };
+
+    const handlePointerMove = (pointerEvent: PointerEvent) => {
+      const delta = startY - pointerEvent.clientY;
+      const maxHeight = getMaxHeight();
+      const nextHeight = Math.min(Math.max(startHeight + delta, pythonPanelMinHeight), maxHeight);
+      setPythonPanelHeight(nextHeight);
+    };
+
+    const cleanup = () => {
+      target.removeEventListener('pointermove', handlePointerMove);
+      target.removeEventListener('pointerup', handlePointerUp);
+      target.removeEventListener('pointercancel', handlePointerCancel);
+      try {
+        target.releasePointerCapture(pointerId);
+      } catch {}
+    };
+
+    const handlePointerUp = () => {
+      cleanup();
+    };
+
+    const handlePointerCancel = () => {
+      cleanup();
+    };
+
+    try {
+      target.setPointerCapture(pointerId);
+    } catch {}
+    target.addEventListener('pointermove', handlePointerMove);
+    target.addEventListener('pointerup', handlePointerUp);
+    target.addEventListener('pointercancel', handlePointerCancel);
+  }, [pythonPanelHeight, pythonPanelMinHeight]);
   
   const renderContent = () => {
     const editor = isDiffMode
@@ -435,13 +510,26 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
       </div>
       <div className="flex-1 flex flex-col bg-secondary overflow-hidden">{renderContent()}</div>
       {isPythonDocument && (
-        <div className="px-4 pb-4">
-          <PythonExecutionPanel
-            nodeId={documentNode.id}
-            code={content}
-            defaults={pythonDefaults}
-            consoleTheme={settings.pythonConsoleTheme}
-          />
+        <div
+          className="flex-shrink-0 flex flex-col bg-secondary"
+          style={{ height: pythonPanelHeight }}
+        >
+          <div
+            className="flex items-center justify-center h-2 cursor-row-resize select-none text-border-color hover:text-primary transition-colors"
+            onPointerDown={handlePythonPanelResizeStart}
+          >
+            <div className="h-0.5 w-14 rounded-full bg-current" />
+          </div>
+          <div className="flex-1 overflow-hidden">
+            <div className="h-full overflow-auto px-4 pb-4">
+              <PythonExecutionPanel
+                nodeId={documentNode.id}
+                code={content}
+                defaults={pythonDefaults}
+                consoleTheme={settings.pythonConsoleTheme}
+              />
+            </div>
+          </div>
         </div>
       )}
       {error && <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-destructive-text p-3 bg-destructive-bg rounded-md shadow-lg z-20">{error}</div>}

--- a/components/PythonExecutionPanel.tsx
+++ b/components/PythonExecutionPanel.tsx
@@ -210,11 +210,11 @@ const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({ nodeId, cod
   }, [environments]);
 
   return (
-    <div className="mt-4 rounded-lg border border-border-color bg-secondary/60">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border-color">
-        <div className="flex items-center gap-2 text-sm font-semibold text-text-main">
+    <div className="h-full flex flex-col text-sm text-text-main">
+      <div className="flex flex-wrap items-center justify-between gap-2 pb-3 border-b border-border-color/50">
+        <div className="flex items-center gap-2 font-semibold">
           <TerminalIcon className="w-4 h-4" />
-          Python Execution
+          <span>Python Execution</span>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -229,86 +229,101 @@ const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({ nodeId, cod
           </Button>
         </div>
       </div>
-      <div className="px-4 py-4 space-y-4 text-sm text-text-main">
-        <div className="flex flex-col gap-2">
-          <label className="text-xs font-semibold text-text-secondary">Virtual Environment</label>
-          <select
-            className="bg-background border border-border-color rounded-md px-3 py-2 text-sm text-text-main focus:outline-none focus:ring-1 focus:ring-primary"
-            value={selectedEnvId ?? AUTO_OPTION_VALUE}
-            onChange={handleEnvironmentChange}
-          >
-            <option value={AUTO_OPTION_VALUE}>Auto-create using defaults (Python {defaults.targetPythonVersion})</option>
-            {environmentOptions.map((option) => (
-              <option key={option.value} value={option.value}>{option.label}</option>
-            ))}
-          </select>
-          {ensureError && <p className="text-xs text-destructive-text">{ensureError}</p>}
-          {runError && <p className="text-xs text-destructive-text">{runError}</p>}
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <label className="text-xs font-semibold text-text-secondary">Console Display</label>
-          <select
-            className="bg-background border border-border-color rounded-md px-3 py-2 text-sm text-text-main focus:outline-none focus:ring-1 focus:ring-primary"
-            value={consoleBehavior}
-            onChange={(event) => {
-              const value = event.target.value as PythonConsoleBehavior;
-              setConsoleBehavior(value);
-              if (typeof window !== 'undefined') {
-                window.localStorage.setItem('docforge.python.consoleBehavior', value);
-              }
-            }}
-          >
-            <option value="in-app">In-app console window</option>
-            <option value="hidden">Hidden (no console window)</option>
-            <option value="windows-terminal" disabled={!isWindows}>
-              {isWindows ? 'Windows Terminal (interactive)' : 'Windows Terminal (Windows only)'}
-            </option>
-          </select>
-          {!isWindows && consoleBehavior === 'windows-terminal' && (
-            <p className="text-xs text-destructive-text">
-              Windows Terminal execution is only available on Windows. Please select a different console option.
-            </p>
-          )}
-        </div>
-
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-xs font-semibold text-text-secondary uppercase tracking-wide">Recent Runs</span>
-            {isRunning && <span className="text-xs text-primary">Running…</span>}
-          </div>
-          {runHistory.length === 0 ? (
-            <p className="text-xs text-text-secondary">No runs recorded yet.</p>
-          ) : (
+      <div className="flex-1 overflow-auto pt-3">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,260px)_1fr] md:items-start">
+          <div className="space-y-4">
             <div className="space-y-2">
-              {runHistory.map((run) => (
-                <button
-                  key={run.runId}
-                  className={`w-full text-left border rounded-md px-3 py-2 text-xs transition-colors ${run.runId === selectedRunId ? 'border-primary bg-primary/10' : 'border-border-color hover:border-primary'}`}
-                  onClick={() => setSelectedRunId(run.runId)}
-                >
-                  <div className="flex items-center justify-between">
-                    <span className="font-semibold text-text-main">{run.status.toUpperCase()}</span>
-                    <span className="text-text-secondary">{formatTimestamp(run.startedAt)}</span>
-                  </div>
-                  <div className="mt-1 text-text-secondary">
-                    Exit Code: {run.exitCode ?? '—'}
-                    {run.errorMessage && <span className="ml-2 text-destructive-text">{run.errorMessage}</span>}
-                  </div>
-                </button>
-              ))}
+              <div className="flex items-center justify-between text-xs font-semibold text-text-secondary uppercase tracking-wide">
+                <span>Virtual Environment</span>
+                {isRunning && <span className="text-primary normal-case">Running…</span>}
+              </div>
+              <select
+                className="w-full bg-background border border-border-color/60 rounded-md px-3 py-1.5 text-sm text-text-main focus:outline-none focus:ring-1 focus:ring-primary"
+                value={selectedEnvId ?? AUTO_OPTION_VALUE}
+                onChange={handleEnvironmentChange}
+              >
+                <option value={AUTO_OPTION_VALUE}>Auto-create using defaults (Python {defaults.targetPythonVersion})</option>
+                {environmentOptions.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+              {ensureError && <p className="text-xs text-destructive-text">{ensureError}</p>}
+              {runError && <p className="text-xs text-destructive-text">{runError}</p>}
             </div>
-          )}
-        </div>
 
-        {currentRun && (
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-xs font-semibold text-text-secondary uppercase tracking-wide">Execution Log</span>
-              <span className="text-xs text-text-secondary">Run ID: {currentRun.runId.slice(0, 8)}</span>
+            <div className="space-y-2">
+              <span className="text-xs font-semibold text-text-secondary uppercase tracking-wide block">Console Display</span>
+              <select
+                className="w-full bg-background border border-border-color/60 rounded-md px-3 py-1.5 text-sm text-text-main focus:outline-none focus:ring-1 focus:ring-primary"
+                value={consoleBehavior}
+                onChange={(event) => {
+                  const value = event.target.value as PythonConsoleBehavior;
+                  setConsoleBehavior(value);
+                  if (typeof window !== 'undefined') {
+                    window.localStorage.setItem('docforge.python.consoleBehavior', value);
+                  }
+                }}
+              >
+                <option value="in-app">In-app console window</option>
+                <option value="hidden">Hidden (no console window)</option>
+                <option value="windows-terminal" disabled={!isWindows}>
+                  {isWindows ? 'Windows Terminal (interactive)' : 'Windows Terminal (Windows only)'}
+                </option>
+              </select>
+              {!isWindows && consoleBehavior === 'windows-terminal' && (
+                <p className="text-xs text-destructive-text">
+                  Windows Terminal execution is only available on Windows. Please select a different console option.
+                </p>
+              )}
             </div>
-            <div className="max-h-60 overflow-y-auto bg-background border border-border-color rounded-md p-3 font-mono text-xs space-y-1">
-              {logEntries.length === 0 ? (
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-xs font-semibold text-text-secondary uppercase tracking-wide">
+                <span>Recent Runs</span>
+                {runHistory.length > 0 && (
+                  <button
+                    type="button"
+                    className="text-xs text-primary hover:underline"
+                    onClick={() => { refreshRuns(selectedRunId).catch(() => undefined); }}
+                  >
+                    Refresh
+                  </button>
+                )}
+              </div>
+              {runHistory.length === 0 ? (
+                <p className="text-xs text-text-secondary">No runs recorded yet.</p>
+              ) : (
+                <div className="space-y-1 max-h-60 overflow-y-auto pr-1">
+                  {runHistory.map((run) => (
+                    <button
+                      key={run.runId}
+                      className={`w-full text-left rounded-md px-3 py-2 text-xs transition-colors border ${run.runId === selectedRunId ? 'border-primary bg-primary/10' : 'border-border-color/60 hover:border-primary/60 bg-background/60'}`}
+                      onClick={() => setSelectedRunId(run.runId)}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-semibold text-text-main">{run.status.toUpperCase()}</span>
+                        <span className="text-text-secondary">{formatTimestamp(run.startedAt)}</span>
+                      </div>
+                      <div className="mt-1 text-text-secondary">
+                        Exit Code: {run.exitCode ?? '—'}
+                        {run.errorMessage && <span className="ml-2 text-destructive-text">{run.errorMessage}</span>}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 min-h-[180px]">
+            <div className="flex items-center justify-between text-xs font-semibold text-text-secondary uppercase tracking-wide">
+              <span>Execution Log</span>
+              {currentRun && <span className="text-text-secondary">Run ID: {currentRun.runId.slice(0, 8)}</span>}
+            </div>
+            <div className="flex-1 overflow-auto rounded-md border border-border-color/60 bg-background/80 p-3 font-mono text-xs space-y-1">
+              {!currentRun ? (
+                <div className="text-text-secondary">Select a run to view its output.</div>
+              ) : logEntries.length === 0 ? (
                 <div className="text-text-secondary">Waiting for output…</div>
               ) : (
                 logEntries.map((entry, index) => (
@@ -319,7 +334,7 @@ const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({ nodeId, cod
               )}
             </div>
           </div>
-        )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a draggable splitter so the Python execution panel height can be resized and remembered
- streamline the panel layout to remove the outer border and present controls/logs more compactly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd48f7692c8332b91fe8ceba7b00c7