### PR TITLE
Fix Python execution panel collapse behavior

### DIFF
--- a/components/PromptEditor.tsx
+++ b/components/PromptEditor.tsx
@@ -53,6 +53,12 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
   });
   
   const pythonPanelMinHeight = 180;
+  const [isPythonPanelCollapsed, setIsPythonPanelCollapsed] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return window.localStorage.getItem('docforge.python.panelCollapsed') === 'true';
+    }
+    return false;
+  });
   const [pythonPanelHeight, setPythonPanelHeight] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('docforge.python.panelHeight');
@@ -512,7 +518,7 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
       {isPythonDocument && (
         <div
           className="flex-shrink-0 flex flex-col bg-secondary"
-          style={{ height: pythonPanelHeight }}
+          style={{ height: isPythonPanelCollapsed ? 'auto' : pythonPanelHeight }}
         >
           <div
             className="w-full h-1.5 cursor-row-resize flex-shrink-0 bg-border-color/50 hover:bg-primary transition-colors duration-200"
@@ -525,6 +531,7 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
                 code={content}
                 defaults={pythonDefaults}
                 consoleTheme={settings.pythonConsoleTheme}
+                onCollapseChange={setIsPythonPanelCollapsed}
               />
             </div>
           </div>

--- a/components/PythonExecutionPanel.tsx
+++ b/components/PythonExecutionPanel.tsx
@@ -19,6 +19,7 @@ interface PythonExecutionPanelProps {
   code: string;
   defaults: PythonEnvironmentDefaults;
   consoleTheme: 'light' | 'dark';
+  onCollapseChange?: (isCollapsed: boolean) => void;
 }
 
 const AUTO_OPTION_VALUE = '__auto__';
@@ -33,7 +34,13 @@ const formatTimestamp = (iso: string | null) => {
   }
 };
 
-const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({ nodeId, code, defaults, consoleTheme }) => {
+const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({
+  nodeId,
+  code,
+  defaults,
+  consoleTheme,
+  onCollapseChange,
+}) => {
   const { addLog } = useLogger();
   const { environments, interpreters, isLoading, isDetecting, refreshEnvironments, refreshInterpreters } = usePythonEnvironments();
   const [settings, setSettings] = useState<NodePythonSettings | null>(null);
@@ -60,6 +67,10 @@ const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({ nodeId, cod
     }
     return false;
   });
+
+  useEffect(() => {
+    onCollapseChange?.(isCollapsed);
+  }, [isCollapsed, onCollapseChange]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -221,7 +232,7 @@ const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({ nodeId, cod
   }, [environments]);
 
   return (
-    <div className="h-full flex flex-col text-sm text-text-main">
+    <div className={`flex flex-col text-sm text-text-main ${isCollapsed ? '' : 'h-full min-h-0'}`}>
       <div className={`flex flex-wrap items-center justify-between gap-2 pb-3 ${isCollapsed ? '' : 'border-b border-border-color/50'}`}>
         <div className="flex items-center gap-2 font-semibold">
           <button
@@ -258,7 +269,7 @@ const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({ nodeId, cod
       </div>
       <div
         id="python-execution-panel-content"
-        className={`flex-1 overflow-auto pt-3 ${isCollapsed ? 'hidden' : ''}`}
+        className={`pt-3 ${isCollapsed ? 'hidden' : 'flex-1 overflow-auto'}`}
         aria-hidden={isCollapsed}
       >
         <div className="grid gap-4 md:grid-cols-[minmax(0,260px)_1fr] md:items-start">


### PR DESCRIPTION
## Summary
- notify the surrounding layout when the Python execution panel is collapsed so the container shrinks instead of leaving a blank area
- adjust the panel markup so collapse state no longer forces a full-height layout when hidden

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd55a346788332b8f03bacefe9df2c