### PR TITLE
Align Python execution panel collapse with templates panel

### DIFF
--- a/components/PromptEditor.tsx
+++ b/components/PromptEditor.tsx
@@ -520,12 +520,14 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
           className="flex-shrink-0 flex flex-col bg-secondary"
           style={{ height: isPythonPanelCollapsed ? 'auto' : pythonPanelHeight }}
         >
-          <div
-            className="w-full h-1.5 cursor-row-resize flex-shrink-0 bg-border-color/50 hover:bg-primary transition-colors duration-200"
-            onPointerDown={handlePythonPanelResizeStart}
-          />
-          <div className="flex-1 overflow-hidden">
-            <div className="h-full overflow-auto px-4 pb-4">
+          {!isPythonPanelCollapsed && (
+            <div
+              className="w-full h-1.5 cursor-row-resize flex-shrink-0 bg-border-color/50 hover:bg-primary transition-colors duration-200"
+              onPointerDown={handlePythonPanelResizeStart}
+            />
+          )}
+          <div className={`${isPythonPanelCollapsed ? 'flex-shrink-0' : 'flex-1'} overflow-hidden`}>
+            <div className={`px-4 ${isPythonPanelCollapsed ? 'py-2' : 'pb-4 h-full overflow-auto'}`}>
               <PythonExecutionPanel
                 nodeId={documentNode.id}
                 code={content}

--- a/components/PythonExecutionPanel.tsx
+++ b/components/PythonExecutionPanel.tsx
@@ -233,7 +233,9 @@ const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({
 
   return (
     <div className={`flex flex-col text-sm text-text-main ${isCollapsed ? '' : 'h-full min-h-0'}`}>
-      <div className={`flex flex-wrap items-center justify-between gap-2 pb-3 ${isCollapsed ? '' : 'border-b border-border-color/50'}`}>
+      <div
+        className={`flex flex-wrap items-center justify-between gap-2 ${isCollapsed ? 'py-2' : 'pt-2 pb-3 border-b border-border-color/50'}`}
+      >
         <div className="flex items-center gap-2 font-semibold">
           <button
             type="button"
@@ -248,24 +250,26 @@ const PythonExecutionPanel: React.FC<PythonExecutionPanelProps> = ({
           <TerminalIcon className="w-4 h-4" />
           <span>Python Execution</span>
         </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="secondary"
-            onClick={() => { refreshEnvironments(); refreshInterpreters(); }}
-            isLoading={isLoading || isDetecting}
-            className="px-2.5 py-1 text-[11px]"
-          >
-            <RefreshIcon className="w-3.5 h-3.5 mr-1" /> Refresh
-          </Button>
-          <Button
-            onClick={handleRun}
-            isLoading={isRunning || isEnsuringEnv}
-            disabled={!code.trim()}
-            className="px-2.5 py-1 text-[11px]"
-          >
-            <TerminalIcon className="w-3.5 h-3.5 mr-1" /> Run Script
-          </Button>
-        </div>
+        {!isCollapsed && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => { refreshEnvironments(); refreshInterpreters(); }}
+              isLoading={isLoading || isDetecting}
+              className="px-2.5 py-1 text-[11px]"
+            >
+              <RefreshIcon className="w-3.5 h-3.5 mr-1" /> Refresh
+            </Button>
+            <Button
+              onClick={handleRun}
+              isLoading={isRunning || isEnsuringEnv}
+              disabled={!code.trim()}
+              className="px-2.5 py-1 text-[11px]"
+            >
+              <TerminalIcon className="w-3.5 h-3.5 mr-1" /> Run Script
+            </Button>
+          </div>
+        )}
       </div>
       <div
         id="python-execution-panel-content"


### PR DESCRIPTION
## Summary
- hide the Python execution panel splitter when collapsed so the panel footprint matches the templates section
- tighten the collapsed header styling and hide action buttons to mirror the templates panel presentation
- adjust panel padding so the collapsed state is compact like the templates panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd58aee6908332b460ff3475e63477