### PR TITLE
Align rename input styling across rename fields

### DIFF
--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -228,7 +228,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
                         onChange={(e) => setRenameValue(e.target.value)}
                         onBlur={handleRenameSubmit}
                         onKeyDown={handleRenameKeyDown}
-                        className="w-full text-left text-xs px-1 rounded bg-background text-text-main ring-1 ring-primary focus:outline-none"
+                        className="w-full text-left text-xs px-1.5 py-1 rounded-md bg-background text-text-main border border-border-color focus:outline-none focus:ring-1 focus:ring-primary"
                     />
                 ) : (
                     <span className="truncate flex-1 px-1">{node.title}</span>

--- a/components/TemplateList.tsx
+++ b/components/TemplateList.tsx
@@ -66,7 +66,7 @@ const TemplateList: React.FC<TemplateListProps> = ({ templates, activeTemplateId
                     onChange={(e) => setRenameValue(e.target.value)}
                     onBlur={handleRenameSubmit}
                     onKeyDown={handleRenameKeyDown}
-                    className="w-full text-left text-xs p-1.5 rounded-md bg-background text-text-main ring-2 ring-primary focus:outline-none"
+                    className="w-full text-left text-xs px-1.5 py-1 rounded-md bg-background text-text-main border border-border-color focus:outline-none focus:ring-1 focus:ring-primary"
                 />
                 </div>
             ) : (


### PR DESCRIPTION
## Summary
- unify rename field styling between the document tree and template list inputs to share padding, radius, and focus treatment

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68dd5cf450048332ab258b4a124706ab