### PR TITLE
Adjust tree selection styling for light mode

### DIFF
--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -201,7 +201,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
             onClick={(e) => !isRenaming && onSelectNode(node.id, e)}
             onDoubleClick={(e) => !isRenaming && handleRenameStart(e)}
             className={`w-full text-left p-1 rounded-md group flex justify-between items-center transition-colors duration-150 text-xs relative focus:outline-none ${
-                isSelected ? 'bg-background text-text-main' : 'hover:bg-border-color/30 text-text-secondary hover:text-text-main'
+                isSelected ? 'bg-tree-selected text-text-main' : 'hover:bg-border-color/30 text-text-secondary hover:text-text-main'
             } ${isFocused ? 'ring-2 ring-primary ring-offset-[-2px] ring-offset-secondary' : ''}`}
         >
             <div className="flex items-center gap-1.5 flex-1 truncate">

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
                         'modal-backdrop': 'var(--color-modal-backdrop)',
                         'tooltip-bg': 'rgb(var(--color-tooltip-bg) / <alpha-value>)',
                         'tooltip-text': 'rgb(var(--color-tooltip-text) / <alpha-value>)',
+                        'tree-selected': 'rgb(var(--color-tree-selected) / <alpha-value>)',
                     },
                     fontFamily: {
                         sans: ['Inter', 'sans-serif'],
@@ -48,12 +49,12 @@
     <style>
         :root {
             /* Light theme variables */
-            --color-background: 245 245 245; --color-secondary: 255 255 255; --color-text-main: 23 23 23; --color-text-secondary: 82 82 82; --color-border: 229 231 235; --color-accent: 99 102 241; --color-accent-hover: 80 70 229; --color-accent-text: 255 255 255; --color-success: 34 197 94; --color-warning: 249 115 22; --color-error: 239 68 68; --color-info: 59 130 246; --color-debug: 22 163 74; --color-destructive-text: 185 28 28; --color-destructive-bg: 254 226 226; --color-destructive-bg-hover: 254 202 202; --color-destructive-border: 252 165 165; --color-modal-backdrop: 0 0 0 / 0.5; --color-tooltip-bg: 23 23 23; --color-tooltip-text: 245 245 245;
+            --color-background: 245 245 245; --color-secondary: 255 255 255; --color-text-main: 23 23 23; --color-text-secondary: 82 82 82; --color-border: 229 231 235; --color-accent: 99 102 241; --color-accent-hover: 80 70 229; --color-accent-text: 255 255 255; --color-success: 34 197 94; --color-warning: 249 115 22; --color-error: 239 68 68; --color-info: 59 130 246; --color-debug: 22 163 74; --color-destructive-text: 185 28 28; --color-destructive-bg: 254 226 226; --color-destructive-bg-hover: 254 202 202; --color-destructive-border: 252 165 165; --color-modal-backdrop: 0 0 0 / 0.5; --color-tooltip-bg: 23 23 23; --color-tooltip-text: 245 245 245; --color-tree-selected: 212 212 212;
             --select-arrow-background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23525252' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
         }
         .dark {
             /* Dark theme variables */
-            --color-background: 23 23 23; --color-secondary: 38 38 38; --color-text-main: 245 245 245; --color-text-secondary: 163 163 163; --color-border: 64 64 64; --color-accent: 129 140 248; --color-accent-hover: 99 102 241; --color-accent-text: 23 23 23; --color-destructive-text: 252 165 165; --color-destructive-bg: 127 29 29 / 0.5; --color-destructive-bg-hover: 127 29 29 / 0.8; --color-destructive-border: 153 27 27; --color-modal-backdrop: 0 0 0 / 0.7; --color-tooltip-bg: 245 245 245; --color-tooltip-text: 23 23 23;
+            --color-background: 23 23 23; --color-secondary: 38 38 38; --color-text-main: 245 245 245; --color-text-secondary: 163 163 163; --color-border: 64 64 64; --color-accent: 129 140 248; --color-accent-hover: 99 102 241; --color-accent-text: 23 23 23; --color-destructive-text: 252 165 165; --color-destructive-bg: 127 29 29 / 0.5; --color-destructive-bg-hover: 127 29 29 / 0.8; --color-destructive-border: 153 27 27; --color-modal-backdrop: 0 0 0 / 0.7; --color-tooltip-bg: 245 245 245; --color-tooltip-text: 23 23 23; --color-tree-selected: 38 38 38;
             --select-arrow-background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23a3a3a3' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
         }
         /* Fix for UI Scaling */


### PR DESCRIPTION
## Summary
- introduce a dedicated `tree-selected` theme color to control document tree selection styling
- update the document tree item to use the new color so light mode selections appear in a darker gray

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd648094a08332b29dc8aaff3f47bf