### PR TITLE
Adjust dark mode selection highlight in dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
         }
         .dark {
             /* Dark theme variables */
-            --color-background: 23 23 23; --color-secondary: 38 38 38; --color-text-main: 245 245 245; --color-text-secondary: 163 163 163; --color-border: 64 64 64; --color-accent: 129 140 248; --color-accent-hover: 99 102 241; --color-accent-text: 23 23 23; --color-destructive-text: 252 165 165; --color-destructive-bg: 127 29 29 / 0.5; --color-destructive-bg-hover: 127 29 29 / 0.8; --color-destructive-border: 153 27 27; --color-modal-backdrop: 0 0 0 / 0.7; --color-tooltip-bg: 245 245 245; --color-tooltip-text: 23 23 23; --color-tree-selected: 38 38 38;
+            --color-background: 23 23 23; --color-secondary: 38 38 38; --color-text-main: 245 245 245; --color-text-secondary: 163 163 163; --color-border: 64 64 64; --color-accent: 129 140 248; --color-accent-hover: 99 102 241; --color-accent-text: 23 23 23; --color-destructive-text: 252 165 165; --color-destructive-bg: 127 29 29 / 0.5; --color-destructive-bg-hover: 127 29 29 / 0.8; --color-destructive-border: 153 27 27; --color-modal-backdrop: 0 0 0 / 0.7; --color-tooltip-bg: 245 245 245; --color-tooltip-text: 23 23 23; --color-tree-selected: 56 56 56;
             --select-arrow-background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23a3a3a3' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
         }
         /* Fix for UI Scaling */


### PR DESCRIPTION
## Summary
- lighten the selected item background in dark mode by adjusting the tree selection theme color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6600cf0883329e63bd6f99e05b57