### PR TITLE
Fix GitHub publishing target

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 DocForge is a desktop application designed to streamline the process of creating, managing, and refining documents for Large Language Models (LLMs). It connects to local AI providers like Ollama, allowing you to leverage the power of AI to improve your documents in a secure, offline-first environment.
 
-![DocForge Screenshot](https://raw.githubusercontent.com/TimSirmov/prompt-forge/main/assets/screenshot.png)
+![DocForge Screenshot](https://raw.githubusercontent.com/TimSirmov/docforge/main/assets/screenshot.png)
 
 ## Key Features
 
@@ -27,7 +27,7 @@ DocForge is a desktop application designed to streamline the process of creating
 
 ## Getting Started
 
-1.  **Download:** Grab the latest release for your operating system from the [Releases](https://github.com/TimSirmov/prompt-forge/releases) page.
+1.  **Download:** Grab the latest release for your operating system from the [Releases](https://github.com/TimSirmov/docforge/releases) page.
 2.  **Run a Local LLM:** Ensure you have a local AI provider like [Ollama](https://ollama.ai/) or [LM Studio](https://lmstudio.ai/) running.
 3.  **Configure:** Launch DocForge, open the Settings view, and select your detected LLM service and a model to use for refinement tasks.
 4.  **Create:** Start creating, organizing, and refining your documents!

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 DocForge is a desktop application designed to streamline the process of creating, managing, and refining documents for Large Language Models (LLMs). It connects to local AI providers like Ollama, allowing you to leverage the power of AI to improve your documents in a secure, offline-first environment.
 
-![DocForge Screenshot](https://raw.githubusercontent.com/TimSirmov/prompt-forge/main/assets/screenshot.png)
+![DocForge Screenshot](https://raw.githubusercontent.com/TimSirmov/docforge/main/assets/screenshot.png)
 
 ## Key Features
 
@@ -27,7 +27,7 @@ DocForge is a desktop application designed to streamline the process of creating
 
 ## Getting Started
 
-1.  **Download:** Grab the latest release for your operating system from the [Releases](https://github.com/TimSirmov/prompt-forge/releases) page.
+1.  **Download:** Grab the latest release for your operating system from the [Releases](https://github.com/TimSirmov/docforge/releases) page.
 2.  **Run a Local LLM:** Ensure you have a local AI provider like [Ollama](https://ollama.ai/) or [LM Studio](https://lmstudio.ai/) running.
 3.  **Configure:** Launch DocForge, open the Settings view, and select your detected LLM service and a model to use for refinement tasks.
 4.  **Create:** Start creating, organizing, and refining your documents!

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TimSirmov/prompt-forge.git"
+    "url": "https://github.com/TimSirmov/docforge.git"
   },
   "dependencies": {
     "better-sqlite3": "^11.1.2",


### PR DESCRIPTION
## Summary
- update the repository metadata to point Electron Builder at the new GitHub project
- refresh README links so download instructions and screenshots reference the docforge repository

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7867c1b08332b8ab51fe4be3be85