### PR TITLE
Add editor font and Markdown code block background settings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { useDocuments } from './hooks/usePrompts';
 import { useTemplates } from './hooks/useTemplates';
 import { useSettings } from './hooks/useSettings';
+import { useTheme } from './hooks/useTheme';
 import { useLLMStatus } from './hooks/useLLMStatus';
 import { useLogger } from './hooks/useLogger';
 import Sidebar from './components/Sidebar';
@@ -28,7 +29,7 @@ import type { DocumentOrFolder, Command, LogMessage, DiscoveredLLMModel, Discove
 import { IconProvider } from './contexts/IconContext';
 import { storageService } from './services/storageService';
 import { llmDiscoveryService } from './services/llmDiscoveryService';
-import { LOCAL_STORAGE_KEYS } from './constants';
+import { LOCAL_STORAGE_KEYS, DEFAULT_SETTINGS } from './constants';
 import { repository } from './services/repository';
 import { DocumentNode } from './components/PromptTreeItem';
 import { formatShortcut, getShortcutMap, formatShortcutForDisplay } from './services/shortcutService';
@@ -88,6 +89,7 @@ const MainApp: React.FC = () => {
     const { settings, saveSettings, loaded: settingsLoaded } = useSettings();
     const { items, addDocument, addFolder, updateItem, commitVersion, deleteItems, moveItems, getDescendantIds, duplicateItems, addDocumentsFromFiles } = useDocuments();
     const { templates, addTemplate, updateTemplate, deleteTemplate, deleteTemplates } = useTemplates();
+    const { theme } = useTheme();
     
     const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
     const [selectedIds, setSelectedIds] = useState(new Set<string>());
@@ -144,13 +146,27 @@ const MainApp: React.FC = () => {
             const bodyFontFamily = (settings.markdownBodyFontFamily || 'Inter, sans-serif').trim() || 'Inter, sans-serif';
             const headingFontFamily = (settings.markdownHeadingFontFamily || bodyFontFamily).trim() || 'Inter, sans-serif';
             const codeFontFamily = (settings.markdownCodeFontFamily || "'JetBrains Mono', monospace").trim() || "'JetBrains Mono', monospace";
+            const lightCodeBlockBackground = settings.markdownCodeBlockBackgroundLight.trim() || DEFAULT_SETTINGS.markdownCodeBlockBackgroundLight;
+            const darkCodeBlockBackground = settings.markdownCodeBlockBackgroundDark.trim() || DEFAULT_SETTINGS.markdownCodeBlockBackgroundDark;
             document.documentElement.style.setProperty('--markdown-body-font-family', bodyFontFamily);
             document.documentElement.style.setProperty('--markdown-heading-font-family', headingFontFamily);
             document.documentElement.style.setProperty('--markdown-code-font-family', codeFontFamily);
             document.documentElement.style.setProperty('--markdown-content-padding', `${settings.markdownContentPadding}px`);
             document.documentElement.style.setProperty('--markdown-paragraph-spacing', String(settings.markdownParagraphSpacing));
+            document.documentElement.style.setProperty('--markdown-code-block-background-light', lightCodeBlockBackground);
+            document.documentElement.style.setProperty('--markdown-code-block-background-dark', darkCodeBlockBackground);
         }
-    }, [settings.markdownFontSize, settings.markdownLineHeight, settings.markdownMaxWidth, settings.markdownHeadingSpacing, settings.markdownCodeFontSize, settings.markdownBodyFontFamily, settings.markdownHeadingFontFamily, settings.markdownCodeFontFamily, settings.markdownContentPadding, settings.markdownParagraphSpacing, settingsLoaded]);
+    }, [settings.markdownFontSize, settings.markdownLineHeight, settings.markdownMaxWidth, settings.markdownHeadingSpacing, settings.markdownCodeFontSize, settings.markdownBodyFontFamily, settings.markdownHeadingFontFamily, settings.markdownCodeFontFamily, settings.markdownContentPadding, settings.markdownParagraphSpacing, settings.markdownCodeBlockBackgroundLight, settings.markdownCodeBlockBackgroundDark, settingsLoaded]);
+
+    useEffect(() => {
+        if (!settingsLoaded) {
+            return;
+        }
+        const lightCodeBlockBackground = settings.markdownCodeBlockBackgroundLight.trim() || DEFAULT_SETTINGS.markdownCodeBlockBackgroundLight;
+        const darkCodeBlockBackground = settings.markdownCodeBlockBackgroundDark.trim() || DEFAULT_SETTINGS.markdownCodeBlockBackgroundDark;
+        const activeBackground = theme === 'dark' ? darkCodeBlockBackground : lightCodeBlockBackground;
+        document.documentElement.style.setProperty('--markdown-code-block-background', activeBackground);
+    }, [theme, settings.markdownCodeBlockBackgroundLight, settings.markdownCodeBlockBackgroundDark, settingsLoaded]);
 
 
     const activeNode = useMemo(() => {

--- a/components/PromptEditor.tsx
+++ b/components/PromptEditor.tsx
@@ -419,6 +419,7 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
             readOnly={false}
             onChange={setContent}
             onScroll={handleEditorScroll}
+            fontFamily={settings.editorFontFamily}
           />
         )
       : (
@@ -429,6 +430,7 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
             onChange={setContent}
             onScroll={handleEditorScroll}
             customShortcuts={settings.customShortcuts}
+            fontFamily={settings.editorFontFamily}
           />
         );
     const preview = <PreviewPane ref={previewScrollRef} content={content} language={language} onScroll={handlePreviewScroll} addLog={addLog} />;

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -42,7 +42,7 @@ const categories: { id: SettingsCategory; label: string; icon: React.FC<{classNa
 ];
 
 
-type FontField = 'markdownBodyFontFamily' | 'markdownHeadingFontFamily' | 'markdownCodeFontFamily';
+type FontField = 'markdownBodyFontFamily' | 'markdownHeadingFontFamily' | 'markdownCodeFontFamily' | 'editorFontFamily';
 type PlatformId = 'mac' | 'windows' | 'linux' | 'generic';
 
 interface FontOption {
@@ -78,6 +78,12 @@ const FONT_PRESETS: Record<FontField, Record<PlatformId, string[]>> = {
     generic: ['"JetBrains Mono", monospace', '"Fira Code", monospace'],
     mac: ['"SF Mono", monospace', '"Menlo", monospace'],
     windows: ['"Cascadia Code", monospace', '"Consolas", monospace'],
+    linux: ['"Ubuntu Mono", monospace', '"DejaVu Sans Mono", monospace'],
+  },
+  editorFontFamily: {
+    generic: ['"Fira Code", monospace', '"Source Code Pro", monospace'],
+    mac: ['"SF Mono", monospace', '"Menlo", monospace'],
+    windows: ['"Consolas", monospace', '"Cascadia Code", monospace'],
     linux: ['"Ubuntu Mono", monospace', '"DejaVu Sans Mono", monospace'],
   },
 };
@@ -556,6 +562,9 @@ const AppearanceSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCu
     const bodyFontOptions = useMemo(() => buildFontOptions('markdownBodyFontFamily', platform), [platform]);
     const headingFontOptions = useMemo(() => buildFontOptions('markdownHeadingFontFamily', platform), [platform]);
     const codeFontOptions = useMemo(() => buildFontOptions('markdownCodeFontFamily', platform), [platform]);
+    const editorFontOptions = useMemo(() => buildFontOptions('editorFontFamily', platform), [platform]);
+    const lightCodeBlockBackground = settings.markdownCodeBlockBackgroundLight.trim() || DEFAULT_SETTINGS.markdownCodeBlockBackgroundLight;
+    const darkCodeBlockBackground = settings.markdownCodeBlockBackgroundDark.trim() || DEFAULT_SETTINGS.markdownCodeBlockBackgroundDark;
 
 
 
@@ -735,6 +744,69 @@ const AppearanceSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCu
                   onChange={(font) => handleFontChange('markdownCodeFontFamily', font)}
                   helperText="Also applies to the Markdown preview's code blocks."
                 />
+                <FontFamilySelector
+                  id="editorFontFamily"
+                  label="Editor Font Family"
+                  description="Choose the default font used in the Monaco-powered text editors."
+                  value={settings.editorFontFamily}
+                  placeholder="Consolas, 'Courier New', monospace"
+                  options={editorFontOptions}
+                  defaultValue={DEFAULT_SETTINGS.editorFontFamily}
+                  onChange={(font) => handleFontChange('editorFontFamily', font)}
+                  helperText="Affects both the primary editor and diff viewer."
+                />
+                <SettingRow
+                  label="Code Block Background (Light Theme)"
+                  description="Adjust the background color for Markdown code blocks when using the light theme."
+                  htmlFor="markdownCodeBlockBackgroundLight"
+                >
+                  <div className="flex items-center gap-3">
+                    <input
+                      id="markdownCodeBlockBackgroundLight"
+                      type="color"
+                      value={lightCodeBlockBackground}
+                      onChange={(event) => setCurrentSettings((prev) => ({ ...prev, markdownCodeBlockBackgroundLight: event.target.value }))}
+                      className="h-10 w-14 rounded-md border border-border-color bg-background cursor-pointer"
+                    />
+                    <span className="font-mono text-xs text-text-secondary">
+                      {lightCodeBlockBackground.toUpperCase()}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="px-2 py-1 text-xs"
+                      onClick={() => setCurrentSettings((prev) => ({ ...prev, markdownCodeBlockBackgroundLight: DEFAULT_SETTINGS.markdownCodeBlockBackgroundLight }))}
+                    >
+                      Reset
+                    </Button>
+                  </div>
+                </SettingRow>
+                <SettingRow
+                  label="Code Block Background (Dark Theme)"
+                  description="Adjust the background color for Markdown code blocks when using the dark theme."
+                  htmlFor="markdownCodeBlockBackgroundDark"
+                >
+                  <div className="flex items-center gap-3">
+                    <input
+                      id="markdownCodeBlockBackgroundDark"
+                      type="color"
+                      value={darkCodeBlockBackground}
+                      onChange={(event) => setCurrentSettings((prev) => ({ ...prev, markdownCodeBlockBackgroundDark: event.target.value }))}
+                      className="h-10 w-14 rounded-md border border-border-color bg-background cursor-pointer"
+                    />
+                    <span className="font-mono text-xs text-text-secondary">
+                      {darkCodeBlockBackground.toUpperCase()}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="px-2 py-1 text-xs"
+                      onClick={() => setCurrentSettings((prev) => ({ ...prev, markdownCodeBlockBackgroundDark: DEFAULT_SETTINGS.markdownCodeBlockBackgroundDark }))}
+                    >
+                      Reset
+                    </Button>
+                  </div>
+                </SettingRow>
             </div>
         </div>
     );

--- a/constants.ts
+++ b/constants.ts
@@ -34,6 +34,9 @@ export const DEFAULT_SETTINGS: Settings = {
   markdownBodyFontFamily: 'Inter, sans-serif',
   markdownHeadingFontFamily: 'Inter, sans-serif',
   markdownCodeFontFamily: '\'JetBrains Mono\', monospace',
+  editorFontFamily: 'Consolas, "Courier New", monospace',
+  markdownCodeBlockBackgroundLight: '#f5f5f5',
+  markdownCodeBlockBackgroundDark: '#1f2933',
   markdownContentPadding: 48,
   markdownParagraphSpacing: 0.75,
   pythonDefaults: {

--- a/services/preview/markdownRenderer.tsx
+++ b/services/preview/markdownRenderer.tsx
@@ -420,7 +420,7 @@ const MarkdownViewer = forwardRef<HTMLDivElement, MarkdownViewerProps>(({ conten
         }
 
         .df-code-block {
-          background: rgba(var(--color-text-secondary), 0.08);
+          background: var(--markdown-code-block-background, rgba(var(--color-text-secondary), 0.08));
           border: 1px solid rgba(var(--color-border), 0.95);
           border-radius: 0.9rem;
           padding: 1.25rem 1.5rem;

--- a/types.ts
+++ b/types.ts
@@ -257,6 +257,9 @@ export interface Settings {
   markdownBodyFontFamily: string;
   markdownHeadingFontFamily: string;
   markdownCodeFontFamily: string;
+  editorFontFamily: string;
+  markdownCodeBlockBackgroundLight: string;
+  markdownCodeBlockBackgroundDark: string;
   markdownContentPadding: number;
   markdownParagraphSpacing: number;
   pythonDefaults: PythonEnvironmentDefaults;


### PR DESCRIPTION
## Summary
- add a configurable setting for the Monaco editor font with a new Consolas-based default
- expose light/dark Markdown code block background color settings and apply them through CSS variables
- update settings UI and rendering logic to honor the new customization options across the editor and preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de8f68c5048332a83bcdb6d7b100a1