### PR TITLE
Add About dialog highlighting project authorship

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,7 +18,8 @@ import InfoView from './components/InfoView';
 import UpdateNotification from './components/UpdateNotification';
 import CreateFromTemplateModal from './components/CreateFromTemplateModal';
 import DocumentHistoryView from './components/PromptHistoryView';
-import { PlusIcon, FolderPlusIcon, TrashIcon, GearIcon, InfoIcon, TerminalIcon, DocumentDuplicateIcon, PencilIcon, CopyIcon, CommandIcon, CodeIcon, FolderDownIcon, FormatIcon } from './components/Icons';
+import { PlusIcon, FolderPlusIcon, TrashIcon, GearIcon, InfoIcon, TerminalIcon, DocumentDuplicateIcon, PencilIcon, CopyIcon, CommandIcon, CodeIcon, FolderDownIcon, FormatIcon, SparklesIcon } from './components/Icons';
+import AboutModal from './components/AboutModal';
 import Header from './components/Header';
 import CustomTitleBar from './components/CustomTitleBar';
 import ConfirmModal from './components/ConfirmModal';
@@ -105,6 +106,7 @@ const MainApp: React.FC = () => {
     const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
     const [commandPaletteSearch, setCommandPaletteSearch] = useState('');
     const [isCreateFromTemplateOpen, setCreateFromTemplateOpen] = useState(false);
+    const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
     const [isNewCodeFileModalOpen, setIsNewCodeFileModalOpen] = useState(false);
     const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
     const [loggerPanelHeight, setLoggerPanelHeight] = useState(DEFAULT_LOGGER_HEIGHT);
@@ -807,6 +809,16 @@ const MainApp: React.FC = () => {
         setIsNewCodeFileModalOpen(true);
     }, [addLog]);
 
+    const handleOpenAbout = useCallback(() => {
+        addLog('INFO', 'User action: Opened About dialog.');
+        setIsAboutModalOpen(true);
+    }, [addLog]);
+
+    const handleCloseAbout = useCallback(() => {
+        addLog('INFO', 'User action: Closed About dialog.');
+        setIsAboutModalOpen(false);
+    }, [addLog]);
+
     const handleFormatDocument = useCallback(() => {
         const activeDoc = items.find(p => p.id === activeNodeId);
         if (activeDoc && activeDoc.type === 'document' && view === 'editor') {
@@ -834,8 +846,9 @@ const MainApp: React.FC = () => {
         { id: 'toggle-editor', name: 'Switch to Editor View', action: () => { addLog('INFO', 'Command: Switch to Editor View.'); setView('editor'); }, category: 'View', icon: PencilIcon, keywords: 'main document' },
         { id: 'toggle-settings', name: 'Toggle Settings View', action: toggleSettingsView, category: 'View', icon: GearIcon, keywords: 'configure options' },
         { id: 'toggle-info', name: 'Toggle Info View', action: () => { addLog('INFO', 'Command: Toggle Info View.'); setView(v => v === 'info' ? 'editor' : 'info'); }, category: 'View', icon: InfoIcon, keywords: 'help docs readme' },
+        { id: 'open-about', name: 'About DocForge', action: handleOpenAbout, category: 'Help', icon: SparklesIcon, keywords: 'about credits information' },
         { id: 'toggle-logs', name: 'Toggle Logs Panel', action: () => { addLog('INFO', 'Command: Toggle Logs Panel.'); setIsLoggerVisible(v => !v); }, category: 'View', icon: TerminalIcon, keywords: 'debug console' },
-    ], [handleNewDocument, handleOpenNewCodeFileModal, handleNewRootFolder, handleDeleteSelection, handleNewTemplate, toggleSettingsView, handleDuplicateSelection, selectedIds, addLog, handleToggleCommandPalette, handleFormatDocument]);
+    ], [handleNewDocument, handleOpenNewCodeFileModal, handleNewRootFolder, handleDeleteSelection, handleNewTemplate, toggleSettingsView, handleDuplicateSelection, selectedIds, addLog, handleToggleCommandPalette, handleFormatDocument, handleOpenAbout]);
 
     const enrichedCommands = useMemo(() => {
       return commands.map(command => {
@@ -1053,6 +1066,7 @@ const MainApp: React.FC = () => {
         onShowEditorView: () => { addLog('INFO', 'User action: Switched to editor view.'); setView('editor'); },
         onToggleLogger: () => { addLog('INFO', `User action: Toggled logger panel ${isLoggerVisible ? 'off' : 'on'}.`); setIsLoggerVisible(v => !v); },
         onOpenCommandPalette: handleOpenCommandPalette,
+        onOpenAbout: handleOpenAbout,
         isInfoViewActive: view === 'info',
         isSettingsViewActive: view === 'settings',
         isEditorViewActive: view === 'editor',
@@ -1192,6 +1206,10 @@ const MainApp: React.FC = () => {
                     onClose={() => setIsNewCodeFileModalOpen(false)}
                     onCreate={handleNewCodeFile}
                 />
+            )}
+
+            {isAboutModalOpen && (
+                <AboutModal onClose={handleCloseAbout} />
             )}
 
             {updateInfo.ready && window.electronAPI?.quitAndInstallUpdate && (

--- a/components/AboutModal.tsx
+++ b/components/AboutModal.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Modal from './Modal';
+
+interface AboutModalProps {
+  onClose: () => void;
+}
+
+const AboutModal: React.FC<AboutModalProps> = ({ onClose }) => {
+  return (
+    <Modal title="About DocForge" onClose={onClose}>
+      <div className="p-6 space-y-6 text-text-main">
+        <div className="text-center space-y-2">
+          <span className="uppercase text-[11px] tracking-[0.4em] text-text-secondary">Design &amp; Concept</span>
+          <h3 className="text-2xl font-bold text-primary">Tim Sinaeve</h3>
+          <p className="text-sm text-text-secondary max-w-xl mx-auto">
+            The DocForge experience was envisioned and artfully directed by Tim Sinaeve, whose design leadership shaped the product's concept and presentation.
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <section className="rounded-lg border border-border-color bg-background/80 p-4 text-center shadow-sm">
+            <h4 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-secondary mb-2">Creative Direction</h4>
+            <p className="text-base font-medium text-text-main">
+              Tim Sinaeve guided the visual system, interaction model, and product narrative that define DocForge.
+            </p>
+          </section>
+
+          <section className="rounded-lg border border-border-color bg-background/80 p-4 text-center shadow-sm">
+            <h4 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-secondary mb-2">Implementation</h4>
+            <p className="text-base font-medium text-text-main">
+              Implementation executed by <span className="font-semibold">Gemini 2.5 Pro</span> and <span className="font-semibold">gpt-5-codex</span>, delivering the engineered application experience.
+            </p>
+          </section>
+        </div>
+
+        <p className="text-sm text-text-main text-center max-w-2xl mx-auto">
+          Design and concept were created by Tim Sinaeve, with implementation meticulously handled by Gemini 2.5 Pro and gpt-5-codex to ensure a reliable, production-ready platform.
+        </p>
+
+        <footer className="pt-4 border-t border-border-color text-center text-xs text-text-secondary">
+          © 2025 Tim Sinaeve. All rights reserved.
+        </footer>
+      </div>
+    </Modal>
+  );
+};
+
+export default AboutModal;

--- a/components/CustomTitleBar.tsx
+++ b/components/CustomTitleBar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import IconButton from './IconButton';
-import { GearIcon, InfoIcon, CommandIcon, TerminalIcon, SearchIcon, MinimizeIcon, MaximizeIcon, RestoreIcon, CloseIcon, PencilIcon } from './Icons';
+import { GearIcon, InfoIcon, CommandIcon, TerminalIcon, SearchIcon, MinimizeIcon, MaximizeIcon, RestoreIcon, CloseIcon, PencilIcon, SparklesIcon } from './Icons';
 import ThemeToggleButton from './ThemeToggleButton';
 import { useLogger } from '../hooks/useLogger';
 import type { Command } from '../types';
@@ -11,6 +11,7 @@ interface CustomTitleBarProps {
   onShowEditorView: () => void;
   onToggleLogger: () => void;
   onOpenCommandPalette: () => void;
+  onOpenAbout: () => void;
   isInfoViewActive: boolean;
   isSettingsViewActive: boolean;
   isEditorViewActive: boolean;
@@ -79,8 +80,8 @@ const WindowControls: React.FC<{ platform: string, isMaximized: boolean }> = ({ 
   return <>{controls}</>;
 };
 
-const CustomTitleBar: React.FC<CustomTitleBarProps> = ({ 
-    onToggleSettingsView, onToggleInfoView, onShowEditorView, onToggleLogger, onOpenCommandPalette, 
+const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
+    onToggleSettingsView, onToggleInfoView, onShowEditorView, onToggleLogger, onOpenCommandPalette, onOpenAbout,
     isInfoViewActive, isSettingsViewActive, isEditorViewActive, commandPaletteTargetRef, commandPaletteInputRef, searchTerm, onSearchTermChange, commands
 }) => {
     const [platform, setPlatform] = useState('');
@@ -126,6 +127,9 @@ const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
                 </IconButton>
                 <IconButton onClick={onToggleInfoView} tooltip={getTooltip('toggle-info', 'Info')} size="xs" className={`not-draggable ${isInfoViewActive ? 'bg-primary/10 text-primary' : ''}`} tooltipPosition="bottom">
                     <InfoIcon className="w-4 h-4" />
+                </IconButton>
+                <IconButton onClick={onOpenAbout} tooltip={getTooltip('open-about', 'About DocForge')} size="xs" className="not-draggable" tooltipPosition="bottom">
+                    <SparklesIcon className="w-4 h-4" />
                 </IconButton>
                 <IconButton onClick={onToggleLogger} tooltip={getTooltip('toggle-logs', 'Logs')} size="xs" className="not-draggable" tooltipPosition="bottom">
                     <TerminalIcon className="w-4 h-4" />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import IconButton from './IconButton';
-import { GearIcon, InfoIcon, CommandIcon, TerminalIcon, PencilIcon } from './Icons';
+import { GearIcon, InfoIcon, CommandIcon, TerminalIcon, PencilIcon, SparklesIcon } from './Icons';
 import ThemeToggleButton from './ThemeToggleButton';
 import type { Command } from '../types';
 
@@ -10,19 +10,21 @@ interface HeaderProps {
   onShowEditorView: () => void;
   onToggleLogger: () => void;
   onOpenCommandPalette: () => void;
+  onOpenAbout: () => void;
   isInfoViewActive: boolean;
   isSettingsViewActive: boolean;
   isEditorViewActive: boolean;
   commands: Command[];
 }
 
-const Header: React.FC<HeaderProps> = ({ 
-  onToggleSettingsView, 
-  onToggleInfoView, 
+const Header: React.FC<HeaderProps> = ({
+  onToggleSettingsView,
+  onToggleInfoView,
   onShowEditorView,
-  onToggleLogger, 
-  onOpenCommandPalette, 
-  isInfoViewActive, 
+  onToggleLogger,
+  onOpenCommandPalette,
+  onOpenAbout,
+  isInfoViewActive,
   isSettingsViewActive,
   isEditorViewActive,
   commands
@@ -47,6 +49,9 @@ const Header: React.FC<HeaderProps> = ({
         </IconButton>
         <IconButton onClick={onToggleInfoView} tooltip={getTooltip('toggle-info', 'Info')} className={`${isInfoViewActive ? 'bg-primary/10 text-primary' : ''}`} tooltipPosition="bottom" size="xs">
           <InfoIcon className="w-4 h-4" />
+        </IconButton>
+        <IconButton onClick={onOpenAbout} tooltip={getTooltip('open-about', 'About DocForge')} tooltipPosition="bottom" size="xs">
+          <SparklesIcon className="w-4 h-4" />
         </IconButton>
         <IconButton onClick={onToggleLogger} tooltip={getTooltip('toggle-logs', 'Logs')} tooltipPosition="bottom" size="xs">
           <TerminalIcon className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- add a dedicated About dialog that credits Tim Sinaeve for design and Gemini 2.5 Pro with gpt-5-codex for implementation
- expose the About dialog through the header/title bar controls and the command palette for easy access

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de99ffd530833282c41117ffc30908