### PR TITLE
Fix Shiki highlighter configuration for markdown syntax highlighting

### DIFF
--- a/services/preview/shikiHighlighter.ts
+++ b/services/preview/shikiHighlighter.ts
@@ -1,15 +1,13 @@
-import type { Highlighter } from 'shiki/bundle/full';
+import type { Highlighter } from 'shiki';
 
 let highlighterPromise: Promise<Highlighter> | null = null;
 
 export const getSharedHighlighter = async (): Promise<Highlighter> => {
   if (!highlighterPromise) {
-    highlighterPromise = import('shiki/bundle/full').then(({ getHighlighter }) =>
+    highlighterPromise = import('shiki/bundle/full').then(({ getHighlighter, bundledLanguages }) =>
       getHighlighter({
-        themes: {
-          light: 'github-light',
-          dark: 'one-dark-pro',
-        },
+        themes: ['github-light', 'one-dark-pro'],
+        langs: Object.keys(bundledLanguages),
       })
     );
   }


### PR DESCRIPTION
## Summary
- adjust the Shiki highlighter setup to use the current API
- preload the bundled languages so markdown code blocks regain syntax colors

## Testing
- npx tsc --noEmit *(fails: existing type issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de9e99b894833298e519b54296abc8