### PR TITLE
Adjust markdown spacing to remove extra gaps

### DIFF
--- a/services/preview/markdownRenderer.tsx
+++ b/services/preview/markdownRenderer.tsx
@@ -340,12 +340,11 @@ const MarkdownViewer = forwardRef<HTMLDivElement, MarkdownViewerProps>(({ conten
         }
 
         .df-markdown > * {
-          margin-top: calc(var(--markdown-font-size, 16px) * var(--markdown-paragraph-spacing, 0.75));
-          margin-bottom: calc(var(--markdown-font-size, 16px) * var(--markdown-paragraph-spacing, 0.75));
+          margin-top: 0;
         }
 
-        .df-markdown > :first-child {
-          margin-top: 0;
+        .df-markdown > * + * {
+          margin-top: calc(var(--markdown-font-size, 16px) * var(--markdown-paragraph-spacing, 0.75));
         }
 
         .df-markdown h1 {


### PR DESCRIPTION
## Summary
- adjust the markdown renderer spacing so only subsequent elements receive top margins

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dea31a315c8332a806ba6f855d44e3