### PR TITLE
Add configurable Monaco editor font size

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1037,6 +1037,7 @@ const MainApp: React.FC = () => {
                             document={activeNode}
                             onBackToEditor={() => setDocumentView('editor')}
                             onRestore={(content) => handleRestoreDocumentVersion(activeNode.id, content)}
+                            settings={settings}
                         />
                     );
                 }

--- a/components/MonacoDiffEditor.tsx
+++ b/components/MonacoDiffEditor.tsx
@@ -14,9 +14,10 @@ interface MonacoDiffEditorProps {
   onChange?: (value: string) => void;
   onScroll?: (scrollInfo: { scrollTop: number; scrollHeight: number; clientHeight: number }) => void;
   fontFamily?: string;
+  fontSize?: number;
 }
 
-const MonacoDiffEditor: React.FC<MonacoDiffEditorProps> = ({ oldText, newText, language, renderMode = 'side-by-side', readOnly = false, onChange, onScroll, fontFamily }) => {
+const MonacoDiffEditor: React.FC<MonacoDiffEditorProps> = ({ oldText, newText, language, renderMode = 'side-by-side', readOnly = false, onChange, onScroll, fontFamily, fontSize }) => {
     const editorRef = useRef<HTMLDivElement>(null);
     const editorInstanceRef = useRef<any>(null);
     const { theme } = useTheme();
@@ -27,6 +28,13 @@ const MonacoDiffEditor: React.FC<MonacoDiffEditorProps> = ({ oldText, newText, l
         const candidate = (fontFamily ?? '').trim();
         return candidate || DEFAULT_SETTINGS.editorFontFamily;
     }, [fontFamily]);
+    const computedFontSize = useMemo(() => {
+        const candidate = typeof fontSize === 'number' ? fontSize : Number(fontSize);
+        if (Number.isFinite(candidate) && candidate > 0) {
+            return Math.min(Math.max(candidate, 8), 64);
+        }
+        return DEFAULT_SETTINGS.editorFontSize;
+    }, [fontSize]);
 
     const disposeListeners = useCallback(() => {
         if (changeListenerRef.current) {
@@ -54,7 +62,7 @@ const MonacoDiffEditor: React.FC<MonacoDiffEditorProps> = ({ oldText, newText, l
                     originalEditable: false,
                     readOnly,
                     automaticLayout: true,
-                    fontSize: 12,
+                    fontSize: computedFontSize,
                     fontFamily: computedFontFamily,
                     wordWrap: 'on',
                     renderSideBySide: renderMode !== 'inline',
@@ -69,6 +77,7 @@ const MonacoDiffEditor: React.FC<MonacoDiffEditorProps> = ({ oldText, newText, l
                 renderSideBySide: renderMode !== 'inline',
                 diffWordWrap: 'on',
                 fontFamily: computedFontFamily,
+                fontSize: computedFontSize,
             });
 
             monaco.editor.setTheme(theme === 'dark' ? 'vs-dark' : 'vs');
@@ -110,13 +119,13 @@ const MonacoDiffEditor: React.FC<MonacoDiffEditorProps> = ({ oldText, newText, l
         return () => {
             isCancelled = true;
         };
-    }, [oldText, newText, language, theme, renderMode, readOnly, onChange, onScroll, disposeListeners, computedFontFamily]);
+    }, [oldText, newText, language, theme, renderMode, readOnly, onChange, onScroll, disposeListeners, computedFontFamily, computedFontSize]);
 
     useEffect(() => {
         if (editorInstanceRef.current) {
-            editorInstanceRef.current.updateOptions({ fontFamily: computedFontFamily });
+            editorInstanceRef.current.updateOptions({ fontFamily: computedFontFamily, fontSize: computedFontSize });
         }
-    }, [computedFontFamily]);
+    }, [computedFontFamily, computedFontSize]);
 
     // Final cleanup on unmount
     useEffect(() => {

--- a/components/PromptEditor.tsx
+++ b/components/PromptEditor.tsx
@@ -420,6 +420,7 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
             onChange={setContent}
             onScroll={handleEditorScroll}
             fontFamily={settings.editorFontFamily}
+            fontSize={settings.editorFontSize}
           />
         )
       : (
@@ -431,6 +432,7 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
             onScroll={handleEditorScroll}
             customShortcuts={settings.customShortcuts}
             fontFamily={settings.editorFontFamily}
+            fontSize={settings.editorFontSize}
           />
         );
     const preview = <PreviewPane ref={previewScrollRef} content={content} language={language} onScroll={handlePreviewScroll} addLog={addLog} />;

--- a/components/PromptHistoryView.tsx
+++ b/components/PromptHistoryView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
-import type { DocumentOrFolder } from '../types';
+import type { DocumentOrFolder, Settings } from '../types';
 import { useDocumentHistory } from '../hooks/usePromptHistory';
 import Button from './Button';
 import MonacoDiffEditor from './MonacoDiffEditor';
@@ -12,13 +12,14 @@ interface DocumentHistoryViewProps {
   document: DocumentOrFolder;
   onBackToEditor: () => void;
   onRestore: (content: string) => void;
+  settings: Settings;
 }
 
 const MIN_VERSIONS_PANEL_WIDTH = 240;
 const MIN_COMPARISON_PANEL_WIDTH = 300;
 const DEFAULT_VERSIONS_PANEL_WIDTH = 320;
 
-const DocumentHistoryView: React.FC<DocumentHistoryViewProps> = ({ document, onBackToEditor, onRestore }) => {
+const DocumentHistoryView: React.FC<DocumentHistoryViewProps> = ({ document, onBackToEditor, onRestore, settings }) => {
   const { versions, deleteVersions } = useDocumentHistory(document.id);
   const [isCopied, setIsCopied] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(0);
@@ -338,6 +339,8 @@ const DocumentHistoryView: React.FC<DocumentHistoryViewProps> = ({ document, onB
                         language={document.language_hint || 'plaintext'}
                         renderMode={diffRenderMode}
                         readOnly
+                        fontFamily={settings.editorFontFamily}
+                        fontSize={settings.editorFontSize}
                     />
                 </div>
             </main>

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -744,6 +744,27 @@ const AppearanceSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCu
                   onChange={(font) => handleFontChange('markdownCodeFontFamily', font)}
                   helperText="Also applies to the Markdown preview's code blocks."
                 />
+                <SettingRow
+                  label="Editor Font Size"
+                  description="Set the default font size for the code editor."
+                  htmlFor="editorFontSize"
+                >
+                  <div className="flex items-center gap-4 w-60">
+                    <input
+                      id="editorFontSize"
+                      type="range"
+                      min="10"
+                      max="32"
+                      step="1"
+                      value={settings.editorFontSize}
+                      onChange={(e) => setCurrentSettings((prev) => ({ ...prev, editorFontSize: Number(e.target.value) }))}
+                      className="w-full h-2 bg-border-color rounded-lg appearance-none cursor-pointer range-slider"
+                    />
+                    <span className="font-semibold text-text-main tabular-nums min-w-[50px] text-right text-xs">
+                      {settings.editorFontSize}px
+                    </span>
+                  </div>
+                </SettingRow>
                 <FontFamilySelector
                   id="editorFontFamily"
                   label="Editor Font Family"

--- a/constants.ts
+++ b/constants.ts
@@ -35,6 +35,7 @@ export const DEFAULT_SETTINGS: Settings = {
   markdownHeadingFontFamily: 'Inter, sans-serif',
   markdownCodeFontFamily: '\'JetBrains Mono\', monospace',
   editorFontFamily: 'Consolas, "Courier New", monospace',
+  editorFontSize: 12,
   markdownCodeBlockBackgroundLight: '#f5f5f5',
   markdownCodeBlockBackgroundDark: '#1f2933',
   markdownContentPadding: 48,

--- a/types.ts
+++ b/types.ts
@@ -258,6 +258,7 @@ export interface Settings {
   markdownHeadingFontFamily: string;
   markdownCodeFontFamily: string;
   editorFontFamily: string;
+  editorFontSize: number;
   markdownCodeBlockBackgroundLight: string;
   markdownCodeBlockBackgroundDark: string;
   markdownContentPadding: number;


### PR DESCRIPTION
## Summary
- add an editor font size property to the persisted settings defaults
- update Monaco editors and history views to respect the selected editor font size
- expose an appearance control for adjusting the editor font size

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deaca82ef48332ae12ebc01729e13f