### PR TITLE
Refine settings view with tabbed navigation

### DIFF
--- a/components/KeyboardShortcutsSection.tsx
+++ b/components/KeyboardShortcutsSection.tsx
@@ -65,7 +65,7 @@ const KeyboardShortcutsSection: React.FC<KeyboardShortcutsSectionProps> = ({ set
     const hasEditorResults = Object.keys(groupedEditorCommands).length > 0;
 
     return (
-        <div id="shortcuts" ref={sectionRef} className="py-6">
+        <div id="shortcuts" ref={sectionRef} className="py-6 focus:outline-none" tabIndex={-1}>
             <h2 className="text-lg font-semibold text-text-main mb-1">Keyboard Shortcuts</h2>
             <p className="text-xs text-text-secondary mb-4">Customize shortcuts for application commands and Monaco editor keybindings.</p>
             


### PR DESCRIPTION
## Summary
- convert the settings view to an accessible tabbed layout that syncs with URL hashes and focuses the active panel
- render only the selected settings section while adding sticky quick-action toolbars for provider, appearance, python, general, database, and advanced categories
- ensure section components expose focus targets and streamlined controls for better keyboard navigation and quick actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deaef64e6c833285e2cf23034881e9