### PR TITLE
Tighten document tree spacing

### DIFF
--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -193,14 +193,14 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       onContextMenu={handleContextMenu}
-      style={{ paddingLeft: `${level * 16}px` }}
+      style={{ paddingLeft: `${level * 10}px` }}
       className="relative"
       data-item-id={node.id}
     >
         <div
             onClick={(e) => !isRenaming && onSelectNode(node.id, e)}
             onDoubleClick={(e) => !isRenaming && handleRenameStart(e)}
-            className={`w-full text-left p-1 rounded-md group flex justify-between items-center transition-colors duration-150 text-xs relative focus:outline-none ${
+            className={`w-full text-left py-0.5 px-1 rounded-md group flex justify-between items-center transition-colors duration-150 text-xs relative focus:outline-none ${
                 isSelected ? 'bg-tree-selected text-text-main' : 'hover:bg-border-color/30 text-text-secondary hover:text-text-main'
             } ${isFocused ? 'ring-2 ring-primary ring-offset-[-2px] ring-offset-secondary' : ''}`}
         >


### PR DESCRIPTION
## Summary
- reduce per-level indentation in the prompt tree for a more compact layout
- shrink vertical padding on tree rows to mimic a Windows-style explorer view

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: project has no dev script; attempted for manual verification)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e2bdd6048332ab175eedf3bf5457