### PR TITLE
Fix lingering drag overlay after importing files

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -309,7 +309,11 @@ const MainApp: React.FC = () => {
 
     const handleDropFiles = useCallback(async (files: FileList, parentId: string | null) => {
         if (!files || files.length === 0) return;
-        
+
+        // Ensure the global drag overlay is cleared when files are dropped anywhere in the app.
+        dragCounter.current = 0;
+        setIsDraggingFile(false);
+
         const fileEntries = Array.from(files).map(file => {
             const f = file as FileWithRelativePath;
             return {


### PR DESCRIPTION
## Summary
- reset the global drag counter and overlay state when files are dropped anywhere in the app
- ensure dragging feedback disappears once documents are imported via the tree view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e110460bdc8332937ac7df3e16ded2