### PR TITLE
Add support for image previews

### DIFF
--- a/components/PreviewPane.tsx
+++ b/components/PreviewPane.tsx
@@ -28,7 +28,7 @@ const PreviewPane = React.forwardRef<HTMLDivElement, PreviewPaneProps>(({ conten
 
       setError(null);
       const renderer = previewService.getRendererForLanguage(language);
-      const result = await renderer.render(content, addLog);
+      const result = await renderer.render(content, addLog, language);
 
       clearTimeout(loadingTimer);
       if (!isCancelled) {

--- a/components/PromptEditor.tsx
+++ b/components/PromptEditor.tsx
@@ -53,7 +53,16 @@ const PREVIEWABLE_LANGUAGES = new Set<string>([
 const resolveDefaultViewMode = (mode: ViewMode | null | undefined, languageHint: string | null | undefined): ViewMode => {
   if (mode) return mode;
   const normalizedHint = languageHint?.toLowerCase();
-  return normalizedHint === 'pdf' || normalizedHint === 'application/pdf' ? 'preview' : 'edit';
+  if (!normalizedHint) {
+    return 'edit';
+  }
+  if (normalizedHint === 'pdf' || normalizedHint === 'application/pdf') {
+    return 'preview';
+  }
+  if (normalizedHint === 'image' || normalizedHint.startsWith('image/')) {
+    return 'preview';
+  }
+  return 'edit';
 };
 
 const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, onCommitVersion, onDelete, settings, onShowHistory, onLanguageChange, onViewModeChange, formatTrigger }) => {

--- a/components/PromptEditor.tsx
+++ b/components/PromptEditor.tsx
@@ -26,6 +26,30 @@ interface DocumentEditorProps {
   formatTrigger: number;
 }
 
+const PREVIEWABLE_LANGUAGES = new Set<string>([
+  'markdown',
+  'html',
+  'pdf',
+  'application/pdf',
+  'image',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'webp',
+  'svg',
+  'svg+xml',
+  'image/png',
+  'image/jpg',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/svg',
+  'image/svg+xml',
+]);
+
 const resolveDefaultViewMode = (mode: ViewMode | null | undefined, languageHint: string | null | undefined): ViewMode => {
   if (mode) return mode;
   const normalizedHint = languageHint?.toLowerCase();
@@ -357,7 +381,7 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
     }
     setRefinedContent(null);
   };
-  
+
   const handleCopy = async () => {
     if (!content.trim()) return;
     await navigator.clipboard.writeText(content);
@@ -367,10 +391,11 @@ const DocumentEditor: React.FC<DocumentEditorProps> = ({ documentNode, onSave, o
   };
 
   const language = documentNode.language_hint || 'plaintext';
-  const supportsAiTools = ['markdown', 'plaintext'].includes(language);
-  const supportsPreview = ['markdown', 'html', 'pdf'].includes(language);
-  const supportsFormatting = ['javascript', 'typescript', 'json', 'html', 'css', 'xml', 'yaml'].includes(language);
-  const isPythonDocument = typeof window !== 'undefined' && !!window.electronAPI && (language === 'python');
+  const normalizedLanguage = language.toLowerCase();
+  const supportsAiTools = ['markdown', 'plaintext'].includes(normalizedLanguage);
+  const supportsPreview = PREVIEWABLE_LANGUAGES.has(normalizedLanguage);
+  const supportsFormatting = ['javascript', 'typescript', 'json', 'html', 'css', 'xml', 'yaml'].includes(normalizedLanguage);
+  const isPythonDocument = typeof window !== 'undefined' && !!window.electronAPI && (normalizedLanguage === 'python');
   const pythonDefaults = useMemo(() => ({
     ...settings.pythonDefaults,
     workingDirectory: settings.pythonWorkingDirectory ?? settings.pythonDefaults.workingDirectory ?? null,

--- a/hooks/useNodes.ts
+++ b/hooks/useNodes.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { Node, ViewMode } from '../types';
+import type { Node, ViewMode, ImportedNodeSummary } from '../types';
 import { repository } from '../services/repository';
 import { useLogger } from './useLogger';
 
@@ -68,9 +68,15 @@ export const useNodes = () => {
       addLog('DEBUG', `Content for node ${nodeId} saved.`);
   }, [addLog]);
 
-  const importFiles = useCallback(async (filesData: {path: string, name: string, content: string}[], targetParentId: string | null) => {
-    await repository.importFiles(filesData, targetParentId);
-  }, []);
+  const importFiles = useCallback(
+    async (
+      filesData: { path: string; name: string; content: string }[],
+      targetParentId: string | null
+    ): Promise<ImportedNodeSummary[]> => {
+      return repository.importFiles(filesData, targetParentId);
+    },
+    []
+  );
 
   return { nodes, isLoading, refreshNodes, addNode, updateNode, deleteNode, deleteNodes, moveNodes, updateDocumentContent, duplicateNodes, importFiles, addLog };
 };

--- a/services/languageService.ts
+++ b/services/languageService.ts
@@ -88,6 +88,7 @@ export const mapExtensionToLanguageId = (extension: string | null): string => {
         case 'bmp':
         case 'webp':
         case 'svg':
+        case 'svgz':
             return 'image';
         case 'image/png':
         case 'image/jpg':

--- a/services/languageService.ts
+++ b/services/languageService.ts
@@ -22,6 +22,7 @@ export const SUPPORTED_LANGUAGES = [
     { id: 'pascal', label: 'Pascal' },
     { id: 'ini', label: 'INI' },
     { id: 'pdf', label: 'PDF' },
+    { id: 'image', label: 'Image (PNG/JPEG/GIF/WebP/SVG/BMP)' },
 ];
 
 export const mapExtensionToLanguageId = (extension: string | null): string => {
@@ -80,6 +81,23 @@ export const mapExtensionToLanguageId = (extension: string | null): string => {
             return 'pdf';
         case 'pdf':
             return 'pdf';
+        case 'png':
+        case 'jpg':
+        case 'jpeg':
+        case 'gif':
+        case 'bmp':
+        case 'webp':
+        case 'svg':
+            return 'image';
+        case 'image/png':
+        case 'image/jpg':
+        case 'image/jpeg':
+        case 'image/gif':
+        case 'image/bmp':
+        case 'image/webp':
+        case 'image/svg':
+        case 'image/svg+xml':
+            return 'image';
         default:
             // Try to find a direct match in supported languages by id
             const match = SUPPORTED_LANGUAGES.find(l => l.id === extension.toLowerCase());

--- a/services/preview/IRenderer.ts
+++ b/services/preview/IRenderer.ts
@@ -10,5 +10,9 @@ export interface IRenderer {
   /**
    * Takes a string of content and transforms it into a renderable React element or HTML string.
    */
-  render(content: string, addLog?: (level: LogLevel, message: string) => void): Promise<{ output: React.ReactElement | string; error?: string }>;
+  render(
+    content: string,
+    addLog?: (level: LogLevel, message: string) => void,
+    languageId?: string | null,
+  ): Promise<{ output: React.ReactElement | string; error?: string }>;
 }

--- a/services/preview/htmlRenderer.tsx
+++ b/services/preview/htmlRenderer.tsx
@@ -7,7 +7,11 @@ export class HtmlRenderer implements IRenderer {
     return languageId === 'html';
   }
 
-  async render(content: string, addLog?: (level: LogLevel, message: string) => void): Promise<{ output: React.ReactElement; error?: string }> {
+  async render(
+    content: string,
+    addLog?: (level: LogLevel, message: string) => void,
+    languageId?: string | null,
+  ): Promise<{ output: React.ReactElement; error?: string }> {
     // Using `color-scheme` allows the iframe content to respect the system's light/dark mode preference.
     const fullHtml = `<html><head><style>body { color-scheme: light dark; font-family: sans-serif; padding: 1rem; }</style></head><body>${content}</body></html>`;
 

--- a/services/preview/imageRenderer.tsx
+++ b/services/preview/imageRenderer.tsx
@@ -1,0 +1,305 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { IRenderer } from './IRenderer';
+import type { LogLevel } from '../../types';
+
+type SupportedImageType =
+  | 'image/png'
+  | 'image/jpeg'
+  | 'image/gif'
+  | 'image/webp'
+  | 'image/bmp'
+  | 'image/svg+xml';
+
+const SUPPORTED_IMAGE_MIME_TYPES: SupportedImageType[] = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/svg+xml',
+];
+
+const FALLBACK_IMAGE_TYPE: SupportedImageType = 'image/png';
+
+const normalizeLanguageToMime = (languageId?: string | null): SupportedImageType | null => {
+  if (!languageId) return null;
+  const normalized = languageId.toLowerCase();
+
+  switch (normalized) {
+    case 'png':
+    case 'image/png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+    case 'image/jpg':
+    case 'image/jpeg':
+      return 'image/jpeg';
+    case 'gif':
+    case 'image/gif':
+      return 'image/gif';
+    case 'webp':
+    case 'image/webp':
+      return 'image/webp';
+    case 'bmp':
+    case 'image/bmp':
+      return 'image/bmp';
+    case 'svg':
+    case 'svg+xml':
+    case 'image/svg':
+    case 'image/svg+xml':
+      return 'image/svg+xml';
+    default:
+      if (normalized.startsWith('image/')) {
+        const match = SUPPORTED_IMAGE_MIME_TYPES.find((type) => type === normalized);
+        return match ?? null;
+      }
+      return null;
+  }
+};
+
+const detectMimeFromBytes = (bytes: Uint8Array): SupportedImageType | null => {
+  if (bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
+    return 'image/png';
+  }
+
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg';
+  }
+
+  if (
+    bytes.length >= 6 &&
+    String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5]).startsWith('GIF')
+  ) {
+    return 'image/gif';
+  }
+
+  if (bytes.length >= 2 && bytes[0] === 0x42 && bytes[1] === 0x4d) {
+    return 'image/bmp';
+  }
+
+  if (
+    bytes.length >= 12 &&
+    String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]) === 'RIFF' &&
+    String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11]) === 'WEBP'
+  ) {
+    return 'image/webp';
+  }
+
+  try {
+    const decoder = new TextDecoder('utf-8', { fatal: false });
+    const sample = decoder.decode(bytes.slice(0, 120)).trim().toLowerCase();
+    if (sample.startsWith('<svg')) {
+      return 'image/svg+xml';
+    }
+  } catch {
+    // Ignore text decoding failures; we'll fall back to other detection strategies.
+  }
+
+  return null;
+};
+
+const createBlobUrlFromBytes = (bytes: Uint8Array, hintedType: SupportedImageType | null) => {
+  const mimeType = detectMimeFromBytes(bytes) ?? hintedType ?? FALLBACK_IMAGE_TYPE;
+  try {
+    return { url: URL.createObjectURL(new Blob([bytes], { type: mimeType })), isBlobUrl: true, mimeType };
+  } catch {
+    return { url: null as string | null, isBlobUrl: false, mimeType };
+  }
+};
+
+const createBlobUrlFromBase64 = (input: string, hintedType: SupportedImageType | null) => {
+  const cleanInput = input.replace(/\s+/g, '');
+  try {
+    const markerIndex = cleanInput.toLowerCase().indexOf('base64,');
+    const payload = markerIndex !== -1 ? cleanInput.slice(markerIndex + 'base64,'.length) : cleanInput;
+    const byteCharacters = atob(payload);
+    const byteLength = byteCharacters.length;
+    const bytes = new Uint8Array(byteLength);
+    for (let i = 0; i < byteLength; i += 1) {
+      bytes[i] = byteCharacters.charCodeAt(i);
+    }
+
+    return createBlobUrlFromBytes(bytes, hintedType);
+  } catch {
+    return { url: null as string | null, isBlobUrl: false, mimeType: hintedType };
+  }
+};
+
+const createBlobUrlFromText = (input: string, hintedType: SupportedImageType | null) => {
+  const mimeType = hintedType ?? 'image/svg+xml';
+  try {
+    const blob = new Blob([input], { type: mimeType });
+    return { url: URL.createObjectURL(blob), isBlobUrl: true, mimeType };
+  } catch {
+    return { url: null as string | null, isBlobUrl: false, mimeType };
+  }
+};
+
+interface ImagePreviewProps extends React.HTMLAttributes<HTMLDivElement> {
+  content: string;
+  languageId?: string | null;
+}
+
+const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(({ content, className, languageId, ...rest }, ref) => {
+  const [dimensions, setDimensions] = useState<{ width: number; height: number } | null>(null);
+
+  const { url, error, isBlobUrl, mimeType } = useMemo(() => {
+    const trimmed = content.trim();
+    if (!trimmed) {
+      return {
+        url: null as string | null,
+        error: 'This document does not contain any image data.',
+        isBlobUrl: false,
+        mimeType: null as SupportedImageType | null,
+      };
+    }
+
+    const hintedType = normalizeLanguageToMime(languageId) ?? null;
+
+    if (/^(https?:|file:)/i.test(trimmed)) {
+      return { url: trimmed, error: null, isBlobUrl: false, mimeType: hintedType };
+    }
+
+    if (trimmed.startsWith('data:image/')) {
+      return { url: trimmed, error: null, isBlobUrl: false, mimeType: hintedType };
+    }
+
+    if (trimmed.startsWith('<svg')) {
+      return { ...createBlobUrlFromText(trimmed, 'image/svg+xml'), error: null };
+    }
+
+    const char0 = trimmed.charCodeAt(0);
+    const char1 = trimmed.charCodeAt(1);
+    const char2 = trimmed.charCodeAt(2);
+    const char3 = trimmed.charCodeAt(3);
+
+    const looksLikeBinaryImage =
+      (char0 === 0x89 && char1 === 0x50 && char2 === 0x4e && char3 === 0x47) || // PNG
+      (char0 === 0xff && char1 === 0xd8 && char2 === 0xff) || // JPEG
+      trimmed.startsWith('GIF8') ||
+      (char0 === 0x42 && char1 === 0x4d) || // BMP
+      (trimmed.startsWith('RIFF') && trimmed.slice(8, 12) === 'WEBP');
+
+    if (looksLikeBinaryImage) {
+      const bytes = new Uint8Array(trimmed.length);
+      for (let i = 0; i < trimmed.length; i += 1) {
+        bytes[i] = trimmed.charCodeAt(i) & 0xff;
+      }
+      const result = createBlobUrlFromBytes(bytes, hintedType);
+      if (result.url) {
+        return { ...result, error: null };
+      }
+    }
+
+    const base64Match = /base64,/i.test(trimmed) || /^[a-z0-9+/=\s]+$/i.test(trimmed);
+    if (base64Match) {
+      const result = createBlobUrlFromBase64(trimmed, hintedType);
+      if (result.url) {
+        return { ...result, error: null };
+      }
+    }
+
+    return {
+      url: null as string | null,
+      error: 'Stored image data is not in a recognized format.',
+      isBlobUrl: false,
+      mimeType: hintedType,
+    };
+  }, [content, languageId]);
+
+  useEffect(() => {
+    return () => {
+      if (isBlobUrl && url) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, [isBlobUrl, url]);
+
+  const handleImageLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = event.currentTarget;
+    setDimensions({ width: naturalWidth, height: naturalHeight });
+  };
+
+  const handleImageError = () => {
+    setDimensions(null);
+  };
+
+  if (error) {
+    return (
+      <div
+        ref={ref}
+        className={`w-full h-full flex items-center justify-center text-text-secondary text-sm ${className ?? ''}`}
+        {...rest}
+      >
+        {error}
+      </div>
+    );
+  }
+
+  if (!url) {
+    return (
+      <div
+        ref={ref}
+        className={`w-full h-full flex items-center justify-center text-text-secondary text-sm ${className ?? ''}`}
+        {...rest}
+      >
+        Unable to display the stored image.
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref} className={`w-full h-full overflow-auto bg-secondary ${className ?? ''}`} {...rest}>
+      <div className="min-h-full min-w-full flex flex-col items-center justify-center p-6">
+        <div className="relative max-w-full">
+          <img
+            src={url}
+            alt="Document preview"
+            onLoad={handleImageLoad}
+            onError={handleImageError}
+            className="max-h-[80vh] max-w-full object-contain rounded-lg shadow-lg border border-border-color bg-background"
+          />
+          {dimensions && (
+            <div className="absolute bottom-3 right-3 rounded-full bg-black/60 px-3 py-1 text-xs text-white shadow-md">
+              {dimensions.width} × {dimensions.height} px
+              {mimeType ? ` • ${mimeType.replace('image/', '').toUpperCase()}` : ''}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+ImagePreview.displayName = 'ImagePreview';
+
+export class ImageRenderer implements IRenderer {
+  private readonly supportedIds = [
+    'image',
+    'png',
+    'jpg',
+    'jpeg',
+    'gif',
+    'bmp',
+    'webp',
+    'svg',
+    'svg+xml',
+    'image/png',
+    'image/jpg',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+    'image/bmp',
+    'image/svg',
+    'image/svg+xml',
+  ];
+
+  canRender(languageId: string): boolean {
+    const normalized = languageId.toLowerCase();
+    return this.supportedIds.includes(normalized);
+  }
+
+  async render(content: string, addLog?: (level: LogLevel, message: string) => void, languageId?: string | null) {
+    return { output: <ImagePreview content={content} languageId={languageId} /> };
+  }
+}

--- a/services/preview/markdownRenderer.tsx
+++ b/services/preview/markdownRenderer.tsx
@@ -691,7 +691,11 @@ export class MarkdownRenderer implements IRenderer {
     return languageId === 'markdown';
   }
 
-  async render(content: string, addLog?: (level: LogLevel, message: string) => void): Promise<{ output: React.ReactElement; error?: string }> {
+  async render(
+    content: string,
+    addLog?: (level: LogLevel, message: string) => void,
+    languageId?: string | null,
+  ): Promise<{ output: React.ReactElement; error?: string }> {
     try {
       return { output: <MarkdownViewer content={content} /> };
     } catch (e) {

--- a/services/preview/pdfRenderer.tsx
+++ b/services/preview/pdfRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import type { IRenderer } from './IRenderer';
+import type { LogLevel } from '../../types';
 
 interface PdfPreviewProps extends React.HTMLAttributes<HTMLDivElement> {
   content: string;
@@ -100,7 +101,7 @@ export class PdfRenderer implements IRenderer {
     return languageId === 'pdf' || languageId === 'application/pdf';
   }
 
-  async render(content: string) {
+  async render(content: string, addLog?: (level: LogLevel, message: string) => void, languageId?: string | null) {
     return { output: <PdfPreview content={content} /> };
   }
 }

--- a/services/preview/plaintextRenderer.tsx
+++ b/services/preview/plaintextRenderer.tsx
@@ -8,7 +8,11 @@ export class PlaintextRenderer implements IRenderer {
     return true;
   }
 
-  async render(content: string, addLog?: (level: LogLevel, message: string) => void): Promise<{ output: React.ReactElement; error?: string }> {
+  async render(
+    content: string,
+    addLog?: (level: LogLevel, message: string) => void,
+    languageId?: string | null,
+  ): Promise<{ output: React.ReactElement; error?: string }> {
     const output = <pre className="whitespace-pre-wrap break-words text-text-secondary">{content}</pre>;
     return { output };
   }

--- a/services/previewService.ts
+++ b/services/previewService.ts
@@ -3,6 +3,7 @@ import { HtmlRenderer } from './preview/htmlRenderer';
 import { MarkdownRenderer } from './preview/markdownRenderer';
 import { PlaintextRenderer } from './preview/plaintextRenderer';
 import { PdfRenderer } from './preview/pdfRenderer';
+import { ImageRenderer } from './preview/imageRenderer';
 
 class PreviewService {
   private renderers: IRenderer[];
@@ -13,6 +14,7 @@ class PreviewService {
       new MarkdownRenderer(),
       new HtmlRenderer(),
       new PdfRenderer(),
+      new ImageRenderer(),
       new PlaintextRenderer(), // Fallback renderer should be last
     ];
   }

--- a/services/repository.ts
+++ b/services/repository.ts
@@ -1,4 +1,15 @@
-import type { Node, Document, DocVersion, DocumentOrFolder, DocumentVersion, DocumentTemplate, Settings, ContentStore, ViewMode } from '../types';
+import type {
+  Node,
+  Document,
+  DocVersion,
+  DocumentOrFolder,
+  DocumentVersion,
+  DocumentTemplate,
+  Settings,
+  ContentStore,
+  ViewMode,
+  ImportedNodeSummary,
+} from '../types';
 import { cryptoService } from './cryptoService';
 import { DEFAULT_SETTINGS, EXAMPLE_TEMPLATES, LOCAL_STORAGE_KEYS } from '../constants';
 import { v4 as uuidv4 } from 'uuid';
@@ -999,7 +1010,7 @@ export const repository = {
         }
     },
 
-    async importFiles(filesData: {path: string, name: string, content: string}[], targetParentId: string | null) {
+    async importFiles(filesData: {path: string, name: string, content: string}[], targetParentId: string | null): Promise<ImportedNodeSummary[]> {
         if (!window.electronAPI?.dbImportFiles) {
             throw new Error("File import is not supported in this environment.");
         }
@@ -1007,6 +1018,7 @@ export const repository = {
         if (!result.success) {
             throw new Error(result.error || 'Failed to import files in main process.');
         }
+        return result.createdNodes ?? [];
     },
 
     async getDbPath(): Promise<string> {

--- a/types.ts
+++ b/types.ts
@@ -18,7 +18,10 @@ declare global {
       dbGetStats: () => Promise<{ success: boolean; stats?: DatabaseStats; error?: string }>;
       dbGetPath: () => Promise<string>;
       // FIX: Add missing `dbImportFiles` to the electronAPI type definition.
-      dbImportFiles: (filesData: {path: string; name: string; content: string}[], targetParentId: string | null) => Promise<{ success: boolean; error?: string }>;
+      dbImportFiles: (
+        filesData: { path: string; name: string; content: string }[],
+        targetParentId: string | null
+      ) => Promise<{ success: boolean; error?: string; createdNodes?: ImportedNodeSummary[] }>;
       legacyFileExists: (filename: string) => Promise<boolean>;
       readLegacyFile: (filename: string) => Promise<{ success: boolean, data?: string, error?: string }>;
       getAppVersion: () => Promise<string>;
@@ -64,8 +67,16 @@ declare global {
 // =================================================================
 
 export type NodeType = 'folder' | 'document';
-export type DocType = 'prompt' | 'source_code' | 'pdf';
+export type DocType = 'prompt' | 'source_code' | 'pdf' | 'image';
 export type ViewMode = 'edit' | 'preview' | 'split-vertical' | 'split-horizontal';
+
+export interface ImportedNodeSummary {
+  nodeId: string;
+  parentId: string | null;
+  docType: DocType;
+  languageHint: string | null;
+  defaultViewMode: ViewMode | null;
+}
 
 export type PythonExecutionStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'canceled';
 


### PR DESCRIPTION
## Summary
- add a dedicated image renderer that supports common formats, generates blob URLs from data strings, and displays dimensions in the preview
- expose the Image language option, map popular image extensions, and surface preview controls for those documents
- pass language hints into preview renderers and update existing renderer implementations to accept the extended signature

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e117d0084483328922d5fb91febd3f