### PR TITLE
Simplify About dialog messaging

### DIFF
--- a/components/AboutModal.tsx
+++ b/components/AboutModal.tsx
@@ -9,36 +9,31 @@ const AboutModal: React.FC<AboutModalProps> = ({ onClose }) => {
   return (
     <Modal title="About DocForge" onClose={onClose}>
       <div className="p-6 space-y-6 text-text-main">
-        <div className="text-center space-y-2">
-          <span className="uppercase text-[11px] tracking-[0.4em] text-text-secondary">Design &amp; Concept</span>
-          <h3 className="text-2xl font-bold text-primary">Tim Sinaeve</h3>
+        <div className="space-y-3 text-center">
+          <h3 className="text-2xl font-bold text-primary">DocForge</h3>
           <p className="text-sm text-text-secondary max-w-xl mx-auto">
-            The DocForge experience was envisioned and artfully directed by Tim Sinaeve, whose design leadership shaped the product's concept and presentation.
+            DocForge blends thoughtful interface design with dependable tooling to keep documentation projects moving forward.
           </p>
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <section className="rounded-lg border border-border-color bg-background/80 p-4 text-center shadow-sm">
-            <h4 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-secondary mb-2">Creative Direction</h4>
-            <p className="text-base font-medium text-text-main">
-              Tim Sinaeve guided the visual system, interaction model, and product narrative that define DocForge.
-            </p>
-          </section>
-
           <section className="rounded-lg border border-border-color bg-background/80 p-4 text-center shadow-sm">
             <h4 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-secondary mb-2">Implementation</h4>
             <p className="text-base font-medium text-text-main">
               Implementation executed by <span className="font-semibold">Gemini 2.5 Pro</span> and <span className="font-semibold">gpt-5-codex</span>, delivering the engineered application experience.
             </p>
           </section>
+
+          <section className="rounded-lg border border-border-color bg-background/80 p-4 text-center shadow-sm">
+            <h4 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-secondary mb-2">Interface Design</h4>
+            <p className="text-base font-medium text-text-main">
+              Interface polish provided with care by Tim Sinaeve.
+            </p>
+          </section>
         </div>
 
-        <p className="text-sm text-text-main text-center max-w-2xl mx-auto">
-          Design and concept were created by Tim Sinaeve, with implementation meticulously handled by Gemini 2.5 Pro and gpt-5-codex to ensure a reliable, production-ready platform.
-        </p>
-
         <footer className="pt-4 border-t border-border-color text-center text-xs text-text-secondary">
-          © 2025 Tim Sinaeve. All rights reserved.
+          © 2025 DocForge Team. All rights reserved.
         </footer>
       </div>
     </Modal>


### PR DESCRIPTION
## Summary
- streamline the About dialog content to focus on DocForge rather than design accolades
- present Tim Sinaeve's design contribution in a modest, single-line note
- update the footer attribution to reflect the DocForge team

## Testing
- not run (UI text change)


------
https://chatgpt.com/codex/tasks/task_e_68e11a0705048332aee363ca1fe65318