### PR TITLE
Add body text search snippets to document tree

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -217,6 +217,7 @@ export interface DocumentOrFolder {
   doc_type?: DocType;
   language_hint?: string | null;
   default_view_mode?: ViewMode | null;
+  searchSnippet?: string;
 }
 
 // Fix: Renamed LegacyPromptVersion to DocumentVersion and aliased it to the new DocVersion type


### PR DESCRIPTION
## Summary
- add a repository helper that scans document body content and returns node ids with contextual snippets
- merge body-search matches into the existing sidebar filtering logic and persist snippet metadata for matched nodes
- highlight search terms and show body snippets inside the sidebar tree while keeping folder expansion behaviour intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11c7142cc8332a031d9848911e6d0