### PR TITLE
chore: prepare 0.6.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ DocForge is a desktop application designed to streamline the process of creating
 4.  **Create:** Start creating, organizing, and refining your documents!
 
 For detailed instructions on usage and features, please refer to the [Functional Manual](./FUNCTIONAL_MANUAL.md).
+To review the history of changes, see the [Version Log](./VERSION_LOG.md).
 
 ## Release Preparation
 
@@ -40,7 +41,8 @@ To create a new public build of DocForge:
 
 1. Update the version in `package.json` and regenerate the lockfile with `npm version <new-version> --no-git-tag-version`.
 2. Review the Markdown documentation (README, manuals, and version log) so the release notes accurately reflect recent changes.
-3. Run `npm run publish` to build the application and publish the artifacts to the configured GitHub release target via Electron Builder.
+3. Sync the documentation copies under `docs/` (README, manuals, version log) with any updates made at the project root.
+4. Run `npm run publish` to build the application and publish the artifacts to the configured GitHub release target via Electron Builder.
 
 ## Application Icon Workflow
 

--- a/VERSION_LOG.md
+++ b/VERSION_LOG.md
@@ -1,5 +1,22 @@
 # Version Log
 
+## v0.6.2 - The Documentation Polish Update
+
+This maintenance release focuses on keeping the documentation set in sync with the
+project's release workflow so the publishing checklist is easy to follow.
+
+### 🛠 Improvements
+
+-   Synced the release preparation guidance between the project README and the
+    documentation bundle to avoid diverging instructions.
+-   Linked the README to the version history so maintainers can quickly review
+    prior changes when drafting release notes.
+
+### 🐛 Fixes
+
+-   Corrected outdated documentation references that omitted the release
+    preparation steps from the published docs bundle.
+
 ## v0.6.1 - The Release Prep Update
 
 This maintenance release focuses on preparing DocForge for distribution by polishing the release workflow and tidying up the documentation set.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,21 @@ DocForge is a desktop application designed to streamline the process of creating
 4.  **Create:** Start creating, organizing, and refining your documents!
 
 For detailed instructions on usage and features, please refer to the [Functional Manual](./FUNCTIONAL_MANUAL.md).
+To review the history of changes, see the [Version Log](./VERSION_LOG.md).
+
+## Release Preparation
+
+To create a new public build of DocForge:
+
+1. Update the version in `package.json` and regenerate the lockfile with `npm version <new-version> --no-git-tag-version`.
+2. Review the Markdown documentation (README, manuals, and version log) so the release notes accurately reflect recent changes.
+3. Sync the documentation copies under `docs/` (README, manuals, version log) with any updates made at the project root.
+4. Run `npm run publish` to build the application and publish the artifacts to the configured GitHub release target via Electron Builder.
+
+## Application Icon Workflow
+
+- The canonical artwork lives at `assets/icon.svg`. Keep this SVG under version control to simplify brand updates.
+- `npm run build` (and any script that calls it) automatically validates the SVG and regenerates `icon.icns`, `icon.ico`, and a high-resolution `icon.png` via the `scripts/prepare-icons.mjs` helper.
+- If the SVG is missing or invalid the script logs a warning and leaves existing binary icons untouched, allowing packaging to proceed with the previously generated assets.
+- Run `npm run prepare:icons` to regenerate the platform-specific icons on demand without rebuilding the JavaScript bundles.
+

--- a/docs/VERSION_LOG.md
+++ b/docs/VERSION_LOG.md
@@ -1,5 +1,22 @@
 # Version Log
 
+## v0.6.2 - The Documentation Polish Update
+
+This maintenance release focuses on keeping the documentation set in sync with the
+project's release workflow so the publishing checklist is easy to follow.
+
+### 🛠 Improvements
+
+-   Synced the release preparation guidance between the project README and the
+    documentation bundle to avoid diverging instructions.
+-   Linked the README to the version history so maintainers can quickly review
+    prior changes when drafting release notes.
+
+### 🐛 Fixes
+
+-   Corrected outdated documentation references that omitted the release
+    preparation steps from the published docs bundle.
+
 ## v0.6.1 - The Release Prep Update
 
 This maintenance release focuses on preparing DocForge for distribution by polishing the release workflow and tidying up the documentation set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docforge",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docforge",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docforge",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "An application to manage and refine documents.",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the application metadata to version 0.6.2 for the documentation polish release
- sync README and docs copies so release preparation guidance and links to the version log stay aligned
- document the new release in the version log for both the project root and bundled docs

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e12439c25c8332999bb5459d510d72