### PR TITLE
Adjust settings panel background

### DIFF
--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -374,7 +374,7 @@ const SettingsView: React.FC<SettingsViewProps> = ({
             ))}
           </ul>
         </nav>
-        <main ref={mainPanelRef} className="flex-1 overflow-y-auto">
+        <main ref={mainPanelRef} className="flex-1 overflow-y-auto bg-secondary">
           <div className="max-w-4xl mx-auto px-8 divide-y divide-border-color/50">
             <ProviderSettingsSection
               {...{


### PR DESCRIPTION
## Summary
- update the settings view main panel to use the secondary surface color so the light theme shows a white background

## Testing
- npm run dev:web

------
https://chatgpt.com/codex/tasks/task_e_68e145164824833291f7d794fa8fb1a5