### PR TITLE
Implement document tab manager and tab UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,7 @@ import { useLLMStatus } from './hooks/useLLMStatus';
 import { useLogger } from './hooks/useLogger';
 import Sidebar from './components/Sidebar';
 import DocumentEditor from './components/PromptEditor';
+import DocumentTabs from './components/DocumentTabs';
 import TemplateEditor from './components/TemplateEditor';
 import { WelcomeScreen } from './components/WelcomeScreen';
 import SettingsView from './components/SettingsView';
@@ -86,13 +87,18 @@ const App: React.FC = () => {
     return <MainApp />;
 };
 
+type TabState = {
+    activeId: string | null;
+    order: string[];
+};
+
 const MainApp: React.FC = () => {
     const { settings, saveSettings, loaded: settingsLoaded } = useSettings();
     const { items, addDocument, addFolder, updateItem, commitVersion, deleteItems, moveItems, getDescendantIds, duplicateItems, addDocumentsFromFiles } = useDocuments();
     const { templates, addTemplate, updateTemplate, deleteTemplate, deleteTemplates } = useTemplates();
     const { theme } = useTheme();
     
-    const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
+    const [tabState, setTabState] = useState<TabState>({ activeId: null, order: [] });
     const [selectedIds, setSelectedIds] = useState(new Set<string>());
     const [lastClickedId, setLastClickedId] = useState<string | null>(null);
     const [activeTemplateId, setActiveTemplateId] = useState<string | null>(null);
@@ -121,6 +127,80 @@ const MainApp: React.FC = () => {
     const [isDraggingFile, setIsDraggingFile] = useState(false);
     const [formatTrigger, setFormatTrigger] = useState(0);
     const [bodySearchMatches, setBodySearchMatches] = useState<Map<string, string>>(new Map());
+
+    const activeNodeId = tabState.activeId;
+    const openDocumentIds = tabState.order;
+
+    const activateDocumentTab = useCallback((documentId: string) => {
+        setTabState(prev => {
+            const exists = prev.order.includes(documentId);
+            if (prev.activeId === documentId && exists) {
+                return prev;
+            }
+            const nextOrder = exists ? prev.order : [...prev.order, documentId];
+            return { order: nextOrder, activeId: documentId };
+        });
+    }, []);
+
+    const setActiveItem = useCallback((id: string | null) => {
+        setTabState(prev => {
+            if (prev.activeId === id) {
+                return prev;
+            }
+            return { order: prev.order, activeId: id };
+        });
+    }, []);
+
+    const closeDocumentTab = useCallback((documentId: string) => {
+        setTabState(prev => {
+            if (!prev.order.includes(documentId)) {
+                return prev;
+            }
+            const nextOrder = prev.order.filter(id => id !== documentId);
+            const nextActive = prev.activeId === documentId
+                ? (nextOrder[nextOrder.length - 1] ?? null)
+                : prev.activeId;
+            return { order: nextOrder, activeId: nextActive };
+        });
+    }, []);
+
+    const closeOtherDocumentTabs = useCallback((documentId: string) => {
+        setTabState(prev => {
+            if (!prev.order.includes(documentId)) {
+                return prev;
+            }
+            return { order: [documentId], activeId: documentId };
+        });
+    }, []);
+
+    const closeDocumentTabsToRight = useCallback((documentId: string) => {
+        setTabState(prev => {
+            const index = prev.order.indexOf(documentId);
+            if (index === -1) {
+                return prev;
+            }
+            const nextOrder = prev.order.slice(0, index + 1);
+            const nextActive = prev.activeId && nextOrder.includes(prev.activeId)
+                ? prev.activeId
+                : documentId;
+            return { order: nextOrder, activeId: nextActive };
+        });
+    }, []);
+
+    const reorderDocumentTabs = useCallback((fromIndex: number, toIndex: number) => {
+        setTabState(prev => {
+            if (fromIndex === toIndex) {
+                return prev;
+            }
+            if (fromIndex < 0 || toIndex < 0 || fromIndex >= prev.order.length || toIndex >= prev.order.length) {
+                return prev;
+            }
+            const nextOrder = [...prev.order];
+            const [moved] = nextOrder.splice(fromIndex, 1);
+            nextOrder.splice(toIndex, 0, moved);
+            return { order: nextOrder, activeId: prev.activeId };
+        });
+    }, []);
 
 
     const isSidebarResizing = useRef(false);
@@ -185,8 +265,8 @@ const MainApp: React.FC = () => {
     }, [items, bodySearchMatches, searchTerm]);
 
     const activeNode = useMemo(() => {
-        return itemsWithSearchMetadata.find(p => p.id === activeNodeId) || null;
-    }, [itemsWithSearchMetadata, activeNodeId]);
+        return itemsWithSearchMetadata.find(p => p.id === tabState.activeId) || null;
+    }, [itemsWithSearchMetadata, tabState.activeId]);
 
     const activeTemplate = useMemo(() => {
         return templates.find(t => t.template_id === activeTemplateId) || null;
@@ -195,6 +275,9 @@ const MainApp: React.FC = () => {
     const activeDocument = useMemo(() => {
         return activeNode?.type === 'document' ? activeNode : null;
     }, [activeNode]);
+
+    const documentItems = useMemo(() => items.filter(item => item.type === 'document'), [items]);
+    const activeDocumentId = activeDocument?.id ?? null;
 
 
     useEffect(() => {
@@ -331,16 +414,67 @@ const MainApp: React.FC = () => {
     }, [expandedFolderIds, settingsLoaded]);
 
     useEffect(() => {
-        if (items.length > 0 && activeNodeId === null && activeTemplateId === null) {
-            const firstId = items[0].id;
-            setActiveNodeId(firstId);
-            setSelectedIds(new Set([firstId]));
-            setLastClickedId(firstId);
-        } else if (items.length === 0 && activeNodeId) {
-            setActiveNodeId(null);
+        if (items.length === 0) {
+            if (openDocumentIds.length > 0 || activeNodeId !== null) {
+                setTabState({ activeId: null, order: [] });
+            }
             setSelectedIds(new Set());
+            setLastClickedId(null);
+            return;
         }
-    }, [items, activeNodeId, activeTemplateId]);
+
+        if (activeTemplateId !== null) {
+            return;
+        }
+
+        if (activeNodeId === null) {
+            const firstItem = items[0];
+            if (firstItem.type === 'document') {
+                activateDocumentTab(firstItem.id);
+            } else {
+                setActiveItem(firstItem.id);
+            }
+            setSelectedIds(new Set([firstItem.id]));
+            setLastClickedId(firstItem.id);
+        }
+    }, [items, activeNodeId, activeTemplateId, openDocumentIds.length, activateDocumentTab, setActiveItem]);
+
+    useEffect(() => {
+        const documentIds = new Set(items.filter(item => item.type === 'document').map(item => item.id));
+        setTabState(prev => {
+            const filteredOrder = prev.order.filter(id => documentIds.has(id));
+            const orderChanged = filteredOrder.length !== prev.order.length;
+            let nextActive = prev.activeId;
+            if (nextActive && !documentIds.has(nextActive)) {
+                nextActive = filteredOrder[filteredOrder.length - 1] ?? null;
+            }
+            if (!orderChanged && nextActive === prev.activeId) {
+                return prev;
+            }
+            return {
+                order: orderChanged ? filteredOrder : prev.order,
+                activeId: nextActive,
+            };
+        });
+    }, [items]);
+
+    useEffect(() => {
+        if (activeTemplateId !== null) {
+            return;
+        }
+        if (activeNodeId && !items.some(item => item.id === activeNodeId)) {
+            const fallbackId = openDocumentIds[openDocumentIds.length - 1] ?? null;
+            if (fallbackId) {
+                setSelectedIds(new Set([fallbackId]));
+                setLastClickedId(fallbackId);
+                activateDocumentTab(fallbackId);
+            } else {
+                setSelectedIds(new Set());
+                setLastClickedId(null);
+                setActiveItem(null);
+            }
+        }
+    }, [items, activeNodeId, activeTemplateId, openDocumentIds, activateDocumentTab, setActiveItem, setSelectedIds, setLastClickedId]);
 
     const handleDetectServices = useCallback(async () => {
         addLog('INFO', 'User action: Detecting LLM services.');
@@ -379,7 +513,7 @@ const MainApp: React.FC = () => {
             const targetNode = imageNodes[imageNodes.length - 1] ?? importedNodes[importedNodes.length - 1];
             if (targetNode) {
                 const nodeForReveal = { id: targetNode.nodeId, type: 'document' as const, parentId: targetNode.parentId };
-                setActiveNodeId(targetNode.nodeId);
+                activateDocumentTab(targetNode.nodeId);
                 setSelectedIds(new Set([targetNode.nodeId]));
                 setLastClickedId(targetNode.nodeId);
                 setActiveTemplateId(null);
@@ -388,7 +522,7 @@ const MainApp: React.FC = () => {
                 ensureNodeVisibleRef.current?.(nodeForReveal);
             }
         }
-    }, [addDocumentsFromFiles, setActiveNodeId, setSelectedIds, setLastClickedId, setActiveTemplateId, setDocumentView, setView]);
+    }, [addDocumentsFromFiles, activateDocumentTab, setSelectedIds, setLastClickedId, setActiveTemplateId, setDocumentView, setView]);
 
     useEffect(() => {
         const handleDragEnter = (e: DragEvent) => {
@@ -520,14 +654,14 @@ const MainApp: React.FC = () => {
         const effectiveParentId = parentId !== undefined ? parentId : getParentIdForNewItem();
         const newDoc = await addDocument({ parentId: effectiveParentId });
         ensureNodeVisible(newDoc);
-        setActiveNodeId(newDoc.id);
+        activateDocumentTab(newDoc.id);
         setSelectedIds(new Set([newDoc.id]));
         setLastClickedId(newDoc.id);
         setActiveTemplateId(null);
         setDocumentView('editor');
         setView('editor');
-    }, [addDocument, getParentIdForNewItem, ensureNodeVisible, addLog]);
-    
+    }, [addDocument, getParentIdForNewItem, ensureNodeVisible, addLog, activateDocumentTab]);
+
     const handleNewCodeFile = useCallback(async (filename: string) => {
         addLog('INFO', `User action: Create New Code File with name "${filename}".`);
         const languageHint = filename.split('.').pop() || null;
@@ -539,26 +673,26 @@ const MainApp: React.FC = () => {
             language_hint: languageHint,
         });
         ensureNodeVisible(newDoc);
-        setActiveNodeId(newDoc.id);
+        activateDocumentTab(newDoc.id);
         setSelectedIds(new Set([newDoc.id]));
         setLastClickedId(newDoc.id);
         setActiveTemplateId(null);
         setDocumentView('editor');
         setView('editor');
-    }, [addDocument, getParentIdForNewItem, ensureNodeVisible, addLog]);
+    }, [addDocument, getParentIdForNewItem, ensureNodeVisible, addLog, activateDocumentTab]);
 
     const handleNewFolder = useCallback(async (parentId?: string | null) => {
         addLog('INFO', 'User action: Create New Folder.');
         const effectiveParentId = parentId !== undefined ? parentId : getParentIdForNewItem();
         const newFolder = await addFolder(effectiveParentId);
         ensureNodeVisible(newFolder);
-        setActiveNodeId(newFolder.id);
+        setActiveItem(newFolder.id);
         setSelectedIds(new Set([newFolder.id]));
         setLastClickedId(newFolder.id);
         setActiveTemplateId(null);
         setDocumentView('editor');
         setView('editor');
-    }, [addFolder, getParentIdForNewItem, ensureNodeVisible, addLog]);
+    }, [addFolder, getParentIdForNewItem, ensureNodeVisible, addLog, setActiveItem]);
 
     const handleNewRootFolder = useCallback(async () => {
         addLog('INFO', 'User action: Create New Root Folder.');
@@ -585,28 +719,28 @@ const MainApp: React.FC = () => {
         const newTemplate = await addTemplate();
         setActiveTemplateId(newTemplate.template_id);
         setLastClickedId(newTemplate.template_id);
-        setActiveNodeId(null);
+        setActiveItem(null);
         setSelectedIds(new Set());
         setView('editor');
-    }, [addTemplate, addLog]);
+    }, [addTemplate, addLog, setActiveItem]);
 
     const handleCreateFromTemplate = useCallback(async (title: string, content: string) => {
         addLog('INFO', `User action: Create Document from Template, title: "${title}".`);
         const newDoc = await addDocument({ parentId: null, title, content });
         ensureNodeVisible(newDoc);
-        setActiveNodeId(newDoc.id);
+        activateDocumentTab(newDoc.id);
         setSelectedIds(new Set([newDoc.id]));
         setLastClickedId(newDoc.id);
         setActiveTemplateId(null);
         setDocumentView('editor');
         setView('editor');
-    }, [addDocument, ensureNodeVisible, addLog]);
+    }, [addDocument, ensureNodeVisible, addLog, activateDocumentTab]);
 
     const handleSelectNode = useCallback((id: string, e: React.MouseEvent) => {
         if (activeNodeId !== id) {
             setDocumentView('editor');
         }
-        
+
         const isShift = e.shiftKey;
         const isCtrl = e.ctrlKey || e.metaKey;
 
@@ -636,18 +770,113 @@ const MainApp: React.FC = () => {
             setLastClickedId(id);
         }
 
-        setActiveNodeId(id);
+        const selectedNode = items.find(item => item.id === id);
+        if (selectedNode?.type === 'document') {
+            activateDocumentTab(id);
+        } else {
+            setActiveItem(id);
+        }
         setActiveTemplateId(null);
         setView('editor');
-    }, [activeNodeId, lastClickedId, navigableItems]);
-    
+    }, [activeNodeId, lastClickedId, navigableItems, items, activateDocumentTab, setActiveItem]);
+
     const handleSelectTemplate = (id: string) => {
         setActiveTemplateId(id);
-        setActiveNodeId(null);
+        setActiveItem(null);
         setSelectedIds(new Set([id]));
         setLastClickedId(id);
         setView('editor');
     };
+
+    const handleActivateTab = useCallback((id: string) => {
+        const node = items.find(item => item.id === id);
+        if (!node || node.type !== 'document') {
+            closeDocumentTab(id);
+            return;
+        }
+        activateDocumentTab(id);
+        setSelectedIds(new Set([id]));
+        setLastClickedId(id);
+        setActiveTemplateId(null);
+        setDocumentView('editor');
+        setView('editor');
+    }, [items, activateDocumentTab, closeDocumentTab, setSelectedIds, setLastClickedId, setActiveTemplateId, setDocumentView, setView]);
+
+    const handleCloseTab = useCallback((id: string) => {
+        if (!openDocumentIds.includes(id)) {
+            return;
+        }
+        const nextOrder = openDocumentIds.filter(tabId => tabId !== id);
+        const wasActive = activeNodeId === id;
+        const nextActive = wasActive ? (nextOrder[nextOrder.length - 1] ?? null) : activeNodeId;
+
+        closeDocumentTab(id);
+
+        if (wasActive) {
+            if (nextActive) {
+                setSelectedIds(new Set([nextActive]));
+                setLastClickedId(nextActive);
+                setActiveTemplateId(null);
+                setDocumentView('editor');
+                setView('editor');
+            } else {
+                setSelectedIds(new Set());
+                setLastClickedId(null);
+            }
+        } else {
+            setSelectedIds(prev => {
+                if (!prev.has(id)) return prev;
+                const next = new Set(prev);
+                next.delete(id);
+                return next;
+            });
+            if (lastClickedId === id) {
+                setLastClickedId(null);
+            }
+        }
+    }, [openDocumentIds, activeNodeId, closeDocumentTab, setSelectedIds, setLastClickedId, setActiveTemplateId, setDocumentView, setView, lastClickedId]);
+
+    const handleCloseOtherTabs = useCallback((id: string) => {
+        if (!openDocumentIds.includes(id)) {
+            return;
+        }
+        closeOtherDocumentTabs(id);
+        setSelectedIds(new Set([id]));
+        setLastClickedId(id);
+        setActiveTemplateId(null);
+        setDocumentView('editor');
+        setView('editor');
+    }, [openDocumentIds, closeOtherDocumentTabs, setSelectedIds, setLastClickedId, setActiveTemplateId, setDocumentView, setView]);
+
+    const handleCloseTabsToRight = useCallback((id: string) => {
+        const index = openDocumentIds.indexOf(id);
+        if (index === -1) {
+            return;
+        }
+        const closingIds = openDocumentIds.slice(index + 1);
+        closeDocumentTabsToRight(id);
+        if (closingIds.length === 0) {
+            return;
+        }
+
+        const activeClosed = activeNodeId ? closingIds.includes(activeNodeId) : false;
+        if (activeClosed) {
+            setSelectedIds(new Set([id]));
+            setLastClickedId(id);
+            setActiveTemplateId(null);
+            setDocumentView('editor');
+            setView('editor');
+        } else {
+            setSelectedIds(prev => {
+                const next = new Set(prev);
+                closingIds.forEach(tabId => next.delete(tabId));
+                return next;
+            });
+            if (lastClickedId && closingIds.includes(lastClickedId)) {
+                setLastClickedId(id);
+            }
+        }
+    }, [openDocumentIds, activeNodeId, closeDocumentTabsToRight, setSelectedIds, setLastClickedId, setActiveTemplateId, setDocumentView, setView, lastClickedId]);
     
     const handleSaveDocumentTitle = (updatedDoc: Partial<Omit<DocumentOrFolder, 'id' | 'content'>>) => {
         if (activeNodeId) {
@@ -766,10 +995,33 @@ const MainApp: React.FC = () => {
             if (lastClickedId && idsToDelete.has(lastClickedId)) {
                 setLastClickedId(null);
             }
-            
-            if (activeNodeId && idsToDelete.has(activeNodeId)) {
-                setActiveNodeId(null);
+
+            const filteredOrder = tabState.order.filter(id => !idsToDelete.has(id));
+            const wasActiveDeleted = activeNodeId ? idsToDelete.has(activeNodeId) : false;
+            const nextActive = wasActiveDeleted ? (filteredOrder[filteredOrder.length - 1] ?? null) : activeNodeId;
+
+            setTabState(prev => {
+                const nextOrder = prev.order.filter(id => !idsToDelete.has(id));
+                let nextActiveId = prev.activeId;
+                if (nextActiveId && idsToDelete.has(nextActiveId)) {
+                    nextActiveId = nextOrder[nextOrder.length - 1] ?? null;
+                }
+                return { order: nextOrder, activeId: nextActiveId };
+            });
+
+            if (wasActiveDeleted) {
+                if (nextActive) {
+                    setSelectedIds(new Set([nextActive]));
+                    setLastClickedId(nextActive);
+                    setActiveTemplateId(null);
+                    setDocumentView('editor');
+                    setView('editor');
+                } else {
+                    setSelectedIds(new Set());
+                    setLastClickedId(null);
+                }
             }
+
             if (activeTemplateId && idsToDelete.has(activeTemplateId)) {
                 setActiveTemplateId(null);
             }
@@ -789,7 +1041,7 @@ const MainApp: React.FC = () => {
                 }
             });
         }
-    }, [items, templates, deleteItems, deleteTemplates, activeNodeId, activeTemplateId, lastClickedId, addLog]);
+    }, [items, templates, deleteItems, deleteTemplates, activeNodeId, activeTemplateId, lastClickedId, addLog, tabState.order, setActiveTemplateId, setDocumentView, setView]);
 
     const handleDeleteNode = useCallback((id: string, shiftKey: boolean = false) => {
         const itemToDelete = items.find(p => p.id === id);
@@ -1217,12 +1469,28 @@ const MainApp: React.FC = () => {
                                     className="w-1.5 cursor-col-resize flex-shrink-0 bg-border-color/50 hover:bg-primary transition-colors duration-200"
                                 />
                                 <section className="flex-1 flex flex-col overflow-hidden bg-background">
-                                    {renderMainContent()}
+                                    {openDocumentIds.length > 0 && (
+                                        <DocumentTabs
+                                            documents={documentItems}
+                                            openDocumentIds={openDocumentIds}
+                                            activeDocumentId={activeDocumentId}
+                                            onSelectTab={handleActivateTab}
+                                            onCloseTab={handleCloseTab}
+                                            onCloseOthers={handleCloseOtherTabs}
+                                            onCloseTabsToRight={handleCloseTabsToRight}
+                                            onReorderTabs={reorderDocumentTabs}
+                                        />
+                                    )}
+                                    <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+                                        {renderMainContent()}
+                                    </div>
                                 </section>
                             </>
                         ) : (
                             <section className="flex-1 flex flex-col overflow-hidden bg-background">
-                                {renderMainContent()}
+                                <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+                                    {renderMainContent()}
+                                </div>
                             </section>
                         )}
                     </main>

--- a/components/DocumentTabs.tsx
+++ b/components/DocumentTabs.tsx
@@ -1,0 +1,274 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { DocumentOrFolder } from '../types';
+import ContextMenu, { MenuItem } from './ContextMenu';
+import { CloseIcon, ChevronDownIcon, FileIcon } from './Icons';
+
+interface DocumentTabsProps {
+    documents: DocumentOrFolder[];
+    openDocumentIds: string[];
+    activeDocumentId: string | null;
+    onSelectTab: (id: string) => void;
+    onCloseTab: (id: string) => void;
+    onCloseOthers: (id: string) => void;
+    onCloseTabsToRight: (id: string) => void;
+    onReorderTabs: (fromIndex: number, toIndex: number) => void;
+}
+
+interface MenuState {
+    isOpen: boolean;
+    position: { x: number; y: number };
+    items: MenuItem[];
+}
+
+const INITIAL_MENU_STATE: MenuState = {
+    isOpen: false,
+    position: { x: 0, y: 0 },
+    items: [],
+};
+
+const DocumentTabs: React.FC<DocumentTabsProps> = ({
+    documents,
+    openDocumentIds,
+    activeDocumentId,
+    onSelectTab,
+    onCloseTab,
+    onCloseOthers,
+    onCloseTabsToRight,
+    onReorderTabs,
+}) => {
+    const docsById = useMemo(() => new Map(documents.map(doc => [doc.id, doc])), [documents]);
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const tabRefs = useRef(new Map<string, HTMLDivElement>());
+    const dragState = useRef<{ id: string | null; index: number }>({ id: null, index: -1 });
+    const [menuState, setMenuState] = useState<MenuState>(INITIAL_MENU_STATE);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+
+    const updateOverflow = useCallback(() => {
+        const container = scrollContainerRef.current;
+        if (!container) {
+            setIsOverflowing(false);
+            return;
+        }
+        setIsOverflowing(container.scrollWidth > container.clientWidth + 1);
+    }, []);
+
+    useEffect(() => {
+        updateOverflow();
+    }, [updateOverflow, openDocumentIds.length, documents]);
+
+    useEffect(() => {
+        const container = scrollContainerRef.current;
+        if (!container || typeof ResizeObserver === 'undefined') return;
+
+        const observer = new ResizeObserver(() => updateOverflow());
+        observer.observe(container);
+        if (container.parentElement) {
+            observer.observe(container.parentElement);
+        }
+        window.addEventListener('resize', updateOverflow);
+        return () => {
+            observer.disconnect();
+            window.removeEventListener('resize', updateOverflow);
+        };
+    }, [updateOverflow]);
+
+    useEffect(() => {
+        if (!activeDocumentId) return;
+        const element = tabRefs.current.get(activeDocumentId);
+        if (element) {
+            element.scrollIntoView({ behavior: 'smooth', inline: 'nearest', block: 'nearest' });
+        }
+    }, [activeDocumentId]);
+
+    const closeMenu = useCallback(() => {
+        setMenuState(INITIAL_MENU_STATE);
+    }, []);
+
+    const openTabMenu = useCallback((event: React.MouseEvent, tabId: string) => {
+        event.preventDefault();
+        const rect = event.currentTarget.getBoundingClientRect();
+        const index = openDocumentIds.indexOf(tabId);
+        const items: MenuItem[] = [
+            { label: 'Close Tab', action: () => onCloseTab(tabId), icon: CloseIcon },
+            {
+                label: 'Close Others',
+                action: () => onCloseOthers(tabId),
+                disabled: openDocumentIds.length <= 1,
+            },
+            {
+                label: 'Close Tabs to Right',
+                action: () => onCloseTabsToRight(tabId),
+                disabled: index === -1 || index === openDocumentIds.length - 1,
+            },
+        ];
+        setMenuState({
+            isOpen: true,
+            position: { x: rect.left, y: rect.bottom + 4 },
+            items,
+        });
+    }, [onCloseOthers, onCloseTab, onCloseTabsToRight, openDocumentIds]);
+
+    const openOverflowMenu = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        const rect = event.currentTarget.getBoundingClientRect();
+        const items: MenuItem[] = openDocumentIds.map((id) => {
+            const doc = docsById.get(id);
+            const displayTitle = doc?.title?.trim() || 'Untitled Document';
+            return {
+                label: displayTitle,
+                action: () => onSelectTab(id),
+                icon: FileIcon,
+                disabled: id === activeDocumentId,
+            };
+        });
+        setMenuState({
+            isOpen: true,
+            position: { x: rect.left, y: rect.bottom + 4 },
+            items,
+        });
+    }, [openDocumentIds, docsById, onSelectTab, activeDocumentId]);
+
+    const handleDragStart = useCallback((event: React.DragEvent<HTMLDivElement>, tabId: string, index: number) => {
+        dragState.current = { id: tabId, index };
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', tabId);
+    }, []);
+
+    const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+    }, []);
+
+    const handleDrop = useCallback((event: React.DragEvent<HTMLDivElement>, targetIndex: number, targetElement: HTMLDivElement) => {
+        event.preventDefault();
+        const draggedId = event.dataTransfer.getData('text/plain') || dragState.current.id;
+        if (!draggedId) return;
+        const fromIndex = openDocumentIds.indexOf(draggedId);
+        if (fromIndex === -1) {
+            dragState.current = { id: null, index: -1 };
+            return;
+        }
+
+        const rect = targetElement.getBoundingClientRect();
+        const dropBefore = event.clientX < rect.left + rect.width / 2;
+        let toIndex = targetIndex;
+        if (!dropBefore) {
+            toIndex = targetIndex + 1;
+        }
+        if (fromIndex === toIndex || fromIndex + 1 === toIndex) {
+            dragState.current = { id: null, index: -1 };
+            return;
+        }
+        if (toIndex > openDocumentIds.length) {
+            toIndex = openDocumentIds.length;
+        }
+        onReorderTabs(fromIndex, toIndex > fromIndex ? toIndex - 1 : toIndex);
+        dragState.current = { id: null, index: -1 };
+    }, [openDocumentIds, onReorderTabs]);
+
+    const handleContainerDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        const draggedId = event.dataTransfer.getData('text/plain') || dragState.current.id;
+        if (!draggedId) return;
+        const fromIndex = openDocumentIds.indexOf(draggedId);
+        if (fromIndex === -1) {
+            dragState.current = { id: null, index: -1 };
+            return;
+        }
+        onReorderTabs(fromIndex, openDocumentIds.length - 1);
+        dragState.current = { id: null, index: -1 };
+    }, [openDocumentIds, onReorderTabs]);
+
+    const handleDragEnd = useCallback(() => {
+        dragState.current = { id: null, index: -1 };
+    }, []);
+
+    const tabElements = openDocumentIds.map((id, index) => {
+        const doc = docsById.get(id);
+        const isActive = id === activeDocumentId;
+        const title = doc?.title?.trim() || 'Untitled Document';
+        return (
+            <div
+                key={id}
+                ref={(element) => {
+                    if (element) {
+                        tabRefs.current.set(id, element);
+                    } else {
+                        tabRefs.current.delete(id);
+                    }
+                }}
+                role="tab"
+                aria-selected={isActive}
+                tabIndex={0}
+                data-tab-id={id}
+                className={`group relative flex items-center gap-2 px-3 py-1.5 border border-b-0 rounded-t-md cursor-pointer select-none transition-colors ${isActive ? 'bg-background text-text-main border-border-color border-b-background shadow-sm' : 'bg-secondary/60 text-text-secondary hover:text-text-main hover:bg-secondary/80 border-border-color/70'}`}
+                onClick={() => onSelectTab(id)}
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        onSelectTab(id);
+                    } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'w') {
+                        event.preventDefault();
+                        onCloseTab(id);
+                    }
+                }}
+                onContextMenu={(event) => openTabMenu(event, id)}
+                draggable
+                onDragStart={(event) => handleDragStart(event, id, index)}
+                onDragOver={handleDragOver}
+                onDrop={(event) => handleDrop(event, index, event.currentTarget)}
+                onDragEnd={handleDragEnd}
+            >
+                <span className="truncate max-w-[160px] text-xs font-medium">
+                    {title}
+                </span>
+                <button
+                    type="button"
+                    className={`flex items-center justify-center rounded-full transition-opacity ${isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        onCloseTab(id);
+                    }}
+                    aria-label={`Close ${title}`}
+                >
+                    <CloseIcon className="w-3.5 h-3.5" />
+                </button>
+            </div>
+        );
+    });
+
+    return (
+        <div className="border-b border-border-color bg-secondary/70">
+            <div className="flex items-center gap-1 px-2">
+                <div
+                    ref={scrollContainerRef}
+                    className="flex-1 overflow-hidden"
+                    onDragOver={handleDragOver}
+                    onDrop={handleContainerDrop}
+                >
+                    <div className="flex items-stretch gap-1 overflow-x-auto py-1 pr-2" role="tablist">
+                        {tabElements}
+                    </div>
+                </div>
+                {isOverflowing && openDocumentIds.length > 0 && (
+                    <button
+                        type="button"
+                        className="flex items-center justify-center w-7 h-7 rounded-md bg-secondary text-text-secondary hover:text-text-main hover:bg-secondary/80 border border-border-color/70"
+                        onClick={openOverflowMenu}
+                        aria-label="Show all tabs"
+                    >
+                        <ChevronDownIcon className="w-4 h-4" />
+                    </button>
+                )}
+            </div>
+            <ContextMenu
+                isOpen={menuState.isOpen}
+                position={menuState.position}
+                items={menuState.items}
+                onClose={closeMenu}
+            />
+        </div>
+    );
+};
+
+export default DocumentTabs;


### PR DESCRIPTION
## Summary
- replace the single document selection state with a tab manager that tracks open documents and the active tab
- update document creation, selection, and deletion flows to keep the tab list consistent
- add a DocumentTabs component that renders closable, reorderable tabs with an overflow menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1446ae13c83328c4bf8be7dffd59d