### PR TITLE
Prepare v0.6.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ To review the history of changes, see the [Version Log](./VERSION_LOG.md).
 To create a new public build of DocForge:
 
 1. Update the version in `package.json` and regenerate the lockfile with `npm version <new-version> --no-git-tag-version`.
-2. Review the Markdown documentation (README, manuals, and version log) so the release notes accurately reflect recent changes.
-3. Sync the documentation copies under `docs/` (README, manuals, version log) with any updates made at the project root.
-4. Run `npm run publish` to build the application and publish the artifacts to the configured GitHub release target via Electron Builder.
+2. Draft the release notes by updating `VERSION_LOG.md` with a new section that summarizes the changes included in the release.
+3. Review the Markdown documentation (README, manuals, and release notes) so the written guidance matches the current workflow.
+4. Sync the documentation copies under `docs/` (README, manuals, version log) with any updates made at the project root.
+5. Run `npm run publish` to build the application and publish the artifacts to the configured GitHub release target via Electron Builder.
 
 ## Application Icon Workflow
 

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -124,8 +124,10 @@ Electron Builder manages the packaging and publishing workflow for DocForge. The
 ### Publishing a Release
 
 1. Run `npm version <new-version> --no-git-tag-version` to bump the version in both `package.json` and `package-lock.json` without creating a Git tag.
-2. Review and update the Markdown documentation (README, manuals, version logs) so the release notes accurately describe the changes.
-3. Execute `npm run publish` to package the application and upload the release artifacts to GitHub.
+2. Update `VERSION_LOG.md` with a new section that captures the highlights of the release.
+3. Review and update the Markdown documentation (README, manuals, release notes) so the written guidance reflects the final state of the build.
+4. Sync the Markdown files under `docs/` with the copies at the project root.
+5. Execute `npm run publish` to package the application and upload the release artifacts to GitHub.
 
 ### Application Icon Pipeline
 

--- a/VERSION_LOG.md
+++ b/VERSION_LOG.md
@@ -1,5 +1,24 @@
 # Version Log
 
+## v0.6.3 - The Release Readiness Refresh
+
+This maintenance release aligns the publishing workflow documentation with the
+latest release checklist so preparing builds remains predictable and
+well-documented.
+
+### 🛠 Improvements
+
+-   Clarified the release preparation steps in the README and technical manual
+    to include drafting release notes and syncing the published documentation
+    bundle.
+-   Ensured the `docs/` copies of the manuals stay in lockstep with the root
+    documentation to avoid drift between the repository and published guides.
+
+### 🐛 Fixes
+
+-   Restored the missing release workflow section in the published technical
+    manual so hosted documentation once again includes the full checklist.
+
 ## v0.6.2 - The Documentation Polish Update
 
 This maintenance release focuses on keeping the documentation set in sync with the

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,9 +40,10 @@ To review the history of changes, see the [Version Log](./VERSION_LOG.md).
 To create a new public build of DocForge:
 
 1. Update the version in `package.json` and regenerate the lockfile with `npm version <new-version> --no-git-tag-version`.
-2. Review the Markdown documentation (README, manuals, and version log) so the release notes accurately reflect recent changes.
-3. Sync the documentation copies under `docs/` (README, manuals, version log) with any updates made at the project root.
-4. Run `npm run publish` to build the application and publish the artifacts to the configured GitHub release target via Electron Builder.
+2. Draft the release notes by updating `VERSION_LOG.md` with a new section that summarizes the changes included in the release.
+3. Review the Markdown documentation (README, manuals, and release notes) so the written guidance matches the current workflow.
+4. Sync the documentation copies under `docs/` (README, manuals, version log) with any updates made at the project root.
+5. Run `npm run publish` to build the application and publish the artifacts to the configured GitHub release target via Electron Builder.
 
 ## Application Icon Workflow
 

--- a/docs/TECHNICAL_MANUAL.md
+++ b/docs/TECHNICAL_MANUAL.md
@@ -110,3 +110,27 @@ This module handles all communication with the external Large Language Model. It
 -   **`DocumentEditor.tsx`:** The primary user-facing editor component. It serves as a layout controller, managing the view mode (editor, preview, split-screen) and containing both the `CodeEditor` (Monaco) and `PreviewPane` components. It orchestrates the flow of data between the editor and the preview.
 -   **`SettingsView.tsx`:** Manages all application settings, which are now read from and saved to the `settings` table in the database.
 -   **`DocumentHistoryView.tsx`:** This view now fetches version history for a document directly from the database, providing a reliable timeline of changes.
+
+---
+
+## 5. Build & Release Workflow
+
+Electron Builder manages the packaging and publishing workflow for DocForge. The most relevant npm scripts are:
+
+-   `npm run build` — Bundles the renderer and preload scripts, prepares assets in `dist/`, and generates platform icon binaries from the source SVG.
+-   `npm run package` — Produces distributable builds without uploading them.
+-   `npm run publish` — Builds the application and publishes artifacts using Electron Builder's configured GitHub target.
+
+### Publishing a Release
+
+1. Run `npm version <new-version> --no-git-tag-version` to bump the version in both `package.json` and `package-lock.json` without creating a Git tag.
+2. Update `VERSION_LOG.md` with a new section that captures the highlights of the release.
+3. Review and update the Markdown documentation (README, manuals, release notes) so the written guidance reflects the final state of the build.
+4. Sync the Markdown files under `docs/` with the copies at the project root.
+5. Execute `npm run publish` to package the application and upload the release artifacts to GitHub.
+
+### Application Icon Pipeline
+
+-   The canonical icon artwork lives at `assets/icon.svg`. During `npm run build` (and thus during `npm run package`/`npm run publish`), the `scripts/prepare-icons.mjs` script validates the SVG and, if valid, generates the required `icon.icns`, `icon.ico`, and `icon.png` files in the `assets/` directory using `icon-gen`.
+-   If the SVG is missing or invalid, the script logs a warning and leaves the existing binary icon assets untouched so packaging can proceed with the previous icons.
+-   To regenerate icons without running a full build, execute `npm run prepare:icons`.

--- a/docs/VERSION_LOG.md
+++ b/docs/VERSION_LOG.md
@@ -1,5 +1,24 @@
 # Version Log
 
+## v0.6.3 - The Release Readiness Refresh
+
+This maintenance release aligns the publishing workflow documentation with the
+latest release checklist so preparing builds remains predictable and
+well-documented.
+
+### 🛠 Improvements
+
+-   Clarified the release preparation steps in the README and technical manual
+    to include drafting release notes and syncing the published documentation
+    bundle.
+-   Ensured the `docs/` copies of the manuals stay in lockstep with the root
+    documentation to avoid drift between the repository and published guides.
+
+### 🐛 Fixes
+
+-   Restored the missing release workflow section in the published technical
+    manual so hosted documentation once again includes the full checklist.
+
 ## v0.6.2 - The Documentation Polish Update
 
 This maintenance release focuses on keeping the documentation set in sync with the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docforge",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docforge",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docforge",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "An application to manage and refine documents.",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the application version to 0.6.3 in package metadata
- refresh the release workflow documentation across the README and technical manual
- add a v0.6.3 entry to the version log and sync the published docs bundle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16137e14c833286d7cef4cf97c255