### PR TITLE
Add automated validation for GUI test plan

### DIFF
--- a/artifacts/gui-test-plan-validation.html
+++ b/artifacts/gui-test-plan-validation.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>GUI Test Plan Validation Results</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  }
+  body {
+    margin: 2rem;
+    background: #f6f7fb;
+    color: #1f2933;
+  }
+  h1 {
+    font-size: 1.8rem;
+    margin-bottom: 1rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #ffffff;
+    box-shadow: 0 1px 4px rgba(15, 23, 42, 0.12);
+  }
+  th, td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: top;
+  }
+  th {
+    background: #1f2937;
+    color: #f9fafb;
+    text-align: left;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+  tr.pass td.status {
+    color: #047857;
+    font-weight: 600;
+  }
+  tr.fail td.status {
+    color: #b91c1c;
+    font-weight: 600;
+  }
+  tr.info td.status {
+    color: #0f172a;
+    font-weight: 600;
+  }
+  tr:nth-child(even) td {
+    background: rgba(15, 23, 42, 0.03);
+  }
+  .meta {
+    margin-bottom: 1rem;
+    color: #4b5563;
+  }
+</style>
+</head>
+<body>
+  <h1>GUI Test Plan Validation Results</h1>
+  <p class="meta">Generated: 2025-10-04T19:14:02.925Z</p>
+  <table>
+    <thead>
+      <tr><th>Test</th><th>Status</th><th>Details</th></tr>
+    </thead>
+    <tbody>
+      <tr class="pass"><td>Heading present: ## 1. Prioritized Test Scenarios</td><td>PASS</td><td>Heading located in document.</td></tr>
+<tr class="pass"><td>Heading present: ## 2. Test Execution Report</td><td>PASS</td><td>Heading located in document.</td></tr>
+<tr class="pass"><td>Heading present: ### 2.1 Execution Summary</td><td>PASS</td><td>Heading located in document.</td></tr>
+<tr class="pass"><td>Heading present: ### 2.2 Impact on Scenario Coverage</td><td>PASS</td><td>Heading located in document.</td></tr>
+<tr class="pass"><td>Heading present: ### 2.3 Blocker Detail</td><td>PASS</td><td>Heading located in document.</td></tr>
+<tr class="pass"><td>Heading present: ### 2.4 Mitigation Plan</td><td>PASS</td><td>Heading located in document.</td></tr>
+<tr class="pass"><td>Execution status format: Application boot and sample workspace load</td><td>PASS</td><td>Execution status "**Blocked** – Preview build cannot be generated because `npm install` fails (node-plantuml requires downloading `viz.js`, which is unreachable in the current offline environment)." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Application boot and sample workspace load</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Document creation and autosave persistence</td><td>PASS</td><td>Execution status "**Blocked** – Depends on successful preview build; prerequisites unavailable." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Document creation and autosave persistence</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Layout responsiveness at critical breakpoints</td><td>PASS</td><td>Execution status "**Blocked** – Requires running UI preview; assets not compiled due to dependency install failure." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Layout responsiveness at critical breakpoints</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Keyboard navigation starting focus</td><td>PASS</td><td>Execution status "**Blocked** – Preview not available; see environment limitation above." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Keyboard navigation starting focus</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Global layout & typography consistency</td><td>PASS</td><td>Execution status "**Blocked** – Screenshot capture requires a compiled build; build step failed." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Global layout & typography consistency</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Editor toolbar theming & state coherence</td><td>PASS</td><td>Execution status "**Blocked** – UI cannot be launched without build artifacts." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Editor toolbar theming & state coherence</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Modal/toast visual system check</td><td>PASS</td><td>Execution status "**Blocked** – Requires running UI preview; blocked by dependency install failure." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Modal/toast visual system check</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Add Markdown document with live preview</td><td>PASS</td><td>Execution status "**Blocked** – Test documents cannot be created without functioning preview environment." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Add Markdown document with live preview</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Add HTML document with preview parity</td><td>PASS</td><td>Execution status "**Blocked** – Preview unavailable; blocked on dependency installation." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Add HTML document with preview parity</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Add PlantUML document preview</td><td>PASS</td><td>Execution status "**Blocked** – PlantUML renderer assets missing because `node-plantuml` post-install script could not download `viz.js`." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Add PlantUML document preview</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Add PDF document preview</td><td>PASS</td><td>Execution status "**Blocked** – Preview environment not runnable without build artifacts." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Add PDF document preview</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Add image asset preview (PNG/JPG)</td><td>PASS</td><td>Execution status "**Blocked** – UI preview build blocked." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Add image asset preview (PNG/JPG)</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Add plaintext document workflow</td><td>PASS</td><td>Execution status "**Blocked** – Dependent on preview build completion; blocked." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Add plaintext document workflow</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Template preview rendering</td><td>PASS</td><td>Execution status "**Blocked** – Preview build artifacts unavailable." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Template preview rendering</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Status bar connection messaging</td><td>PASS</td><td>Execution status "**Blocked** – Cannot verify without running UI." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Status bar connection messaging</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Cross-view iconography audit</td><td>PASS</td><td>Execution status "**Blocked** – Requires visual inspection of preview build; blocked." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Cross-view iconography audit</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: Dark mode typography & contrast check</td><td>PASS</td><td>Execution status "**Blocked** – UI preview unavailable." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: Dark mode typography & contrast check</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Execution status format: High DPI rendering review</td><td>PASS</td><td>Execution status "**Blocked** – Preview build blocked; cannot execute scenario." uses an approved label.</td></tr>
+<tr class="pass"><td>Unique scenario name: High DPI rendering review</td><td>PASS</td><td>Scenario name is unique within the matrix.</td></tr>
+<tr class="pass"><td>Markdown document scenario present</td><td>PASS</td><td>Scenario covering Markdown documents is present.</td></tr>
+<tr class="pass"><td>HTML document scenario present</td><td>PASS</td><td>Scenario covering HTML documents is present.</td></tr>
+<tr class="pass"><td>PlantUML document scenario present</td><td>PASS</td><td>Scenario covering PlantUML documents is present.</td></tr>
+<tr class="pass"><td>PDF document scenario present</td><td>PASS</td><td>Scenario covering PDF documents is present.</td></tr>
+<tr class="pass"><td>Image document scenario present</td><td>PASS</td><td>Scenario covering PNG documents is present.</td></tr>
+<tr class="pass"><td>Plaintext document scenario present</td><td>PASS</td><td>Scenario covering plaintext documents is present.</td></tr>
+<tr class="pass"><td>Scenario coverage summary</td><td>PASS</td><td>Scenario counts — Pass: 0, Fail: 0, Blocked: 18, Not Run: 0.</td></tr>
+      <tr class="info"><td colspan="3"><strong>Summary:</strong> Pass 0, Fail 0, Blocked 18, Not Run 0</td></tr>
+    </tbody>
+  </table>
+</body>
+</html>

--- a/artifacts/gui-test-plan-validation.json
+++ b/artifacts/gui-test-plan-validation.json
@@ -1,0 +1,257 @@
+{
+  "timestamp": "2025-10-04T19:14:02.925Z",
+  "validations": [
+    {
+      "name": "Heading present: ## 1. Prioritized Test Scenarios",
+      "status": "pass",
+      "details": "Heading located in document."
+    },
+    {
+      "name": "Heading present: ## 2. Test Execution Report",
+      "status": "pass",
+      "details": "Heading located in document."
+    },
+    {
+      "name": "Heading present: ### 2.1 Execution Summary",
+      "status": "pass",
+      "details": "Heading located in document."
+    },
+    {
+      "name": "Heading present: ### 2.2 Impact on Scenario Coverage",
+      "status": "pass",
+      "details": "Heading located in document."
+    },
+    {
+      "name": "Heading present: ### 2.3 Blocker Detail",
+      "status": "pass",
+      "details": "Heading located in document."
+    },
+    {
+      "name": "Heading present: ### 2.4 Mitigation Plan",
+      "status": "pass",
+      "details": "Heading located in document."
+    },
+    {
+      "name": "Execution status format: Application boot and sample workspace load",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Preview build cannot be generated because `npm install` fails (node-plantuml requires downloading `viz.js`, which is unreachable in the current offline environment).\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Application boot and sample workspace load",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Document creation and autosave persistence",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Depends on successful preview build; prerequisites unavailable.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Document creation and autosave persistence",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Layout responsiveness at critical breakpoints",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Requires running UI preview; assets not compiled due to dependency install failure.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Layout responsiveness at critical breakpoints",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Keyboard navigation starting focus",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Preview not available; see environment limitation above.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Keyboard navigation starting focus",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Global layout & typography consistency",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Screenshot capture requires a compiled build; build step failed.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Global layout & typography consistency",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Editor toolbar theming & state coherence",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – UI cannot be launched without build artifacts.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Editor toolbar theming & state coherence",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Modal/toast visual system check",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Requires running UI preview; blocked by dependency install failure.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Modal/toast visual system check",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Add Markdown document with live preview",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Test documents cannot be created without functioning preview environment.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Add Markdown document with live preview",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Add HTML document with preview parity",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Preview unavailable; blocked on dependency installation.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Add HTML document with preview parity",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Add PlantUML document preview",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – PlantUML renderer assets missing because `node-plantuml` post-install script could not download `viz.js`.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Add PlantUML document preview",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Add PDF document preview",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Preview environment not runnable without build artifacts.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Add PDF document preview",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Add image asset preview (PNG/JPG)",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – UI preview build blocked.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Add image asset preview (PNG/JPG)",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Add plaintext document workflow",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Dependent on preview build completion; blocked.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Add plaintext document workflow",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Template preview rendering",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Preview build artifacts unavailable.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Template preview rendering",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Status bar connection messaging",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Cannot verify without running UI.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Status bar connection messaging",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Cross-view iconography audit",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Requires visual inspection of preview build; blocked.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Cross-view iconography audit",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: Dark mode typography & contrast check",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – UI preview unavailable.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: Dark mode typography & contrast check",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Execution status format: High DPI rendering review",
+      "status": "pass",
+      "details": "Execution status \"**Blocked** – Preview build blocked; cannot execute scenario.\" uses an approved label."
+    },
+    {
+      "name": "Unique scenario name: High DPI rendering review",
+      "status": "pass",
+      "details": "Scenario name is unique within the matrix."
+    },
+    {
+      "name": "Markdown document scenario present",
+      "status": "pass",
+      "details": "Scenario covering Markdown documents is present."
+    },
+    {
+      "name": "HTML document scenario present",
+      "status": "pass",
+      "details": "Scenario covering HTML documents is present."
+    },
+    {
+      "name": "PlantUML document scenario present",
+      "status": "pass",
+      "details": "Scenario covering PlantUML documents is present."
+    },
+    {
+      "name": "PDF document scenario present",
+      "status": "pass",
+      "details": "Scenario covering PDF documents is present."
+    },
+    {
+      "name": "Image document scenario present",
+      "status": "pass",
+      "details": "Scenario covering PNG documents is present."
+    },
+    {
+      "name": "Plaintext document scenario present",
+      "status": "pass",
+      "details": "Scenario covering plaintext documents is present."
+    },
+    {
+      "name": "Scenario coverage summary",
+      "status": "pass",
+      "details": "Scenario counts — Pass: 0, Fail: 0, Blocked: 18, Not Run: 0."
+    }
+  ],
+  "failures": [],
+  "statusCounts": {
+    "pass": 0,
+    "fail": 0,
+    "blocked": 18,
+    "notRun": 0
+  }
+}

--- a/artifacts/gui-test-plan-validation.md
+++ b/artifacts/gui-test-plan-validation.md
@@ -1,0 +1,57 @@
+# GUI Test Plan Validation Results
+
+Generated: 2025-10-04T19:14:02.925Z
+
+| Test | Status | Details |
+| --- | --- | --- |
+| Heading present: ## 1. Prioritized Test Scenarios | PASS | Heading located in document. |
+| Heading present: ## 2. Test Execution Report | PASS | Heading located in document. |
+| Heading present: ### 2.1 Execution Summary | PASS | Heading located in document. |
+| Heading present: ### 2.2 Impact on Scenario Coverage | PASS | Heading located in document. |
+| Heading present: ### 2.3 Blocker Detail | PASS | Heading located in document. |
+| Heading present: ### 2.4 Mitigation Plan | PASS | Heading located in document. |
+| Execution status format: Application boot and sample workspace load | PASS | Execution status "**Blocked** – Preview build cannot be generated because `npm install` fails (node-plantuml requires downloading `viz.js`, which is unreachable in the current offline environment)." uses an approved label. |
+| Unique scenario name: Application boot and sample workspace load | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Document creation and autosave persistence | PASS | Execution status "**Blocked** – Depends on successful preview build; prerequisites unavailable." uses an approved label. |
+| Unique scenario name: Document creation and autosave persistence | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Layout responsiveness at critical breakpoints | PASS | Execution status "**Blocked** – Requires running UI preview; assets not compiled due to dependency install failure." uses an approved label. |
+| Unique scenario name: Layout responsiveness at critical breakpoints | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Keyboard navigation starting focus | PASS | Execution status "**Blocked** – Preview not available; see environment limitation above." uses an approved label. |
+| Unique scenario name: Keyboard navigation starting focus | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Global layout & typography consistency | PASS | Execution status "**Blocked** – Screenshot capture requires a compiled build; build step failed." uses an approved label. |
+| Unique scenario name: Global layout & typography consistency | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Editor toolbar theming & state coherence | PASS | Execution status "**Blocked** – UI cannot be launched without build artifacts." uses an approved label. |
+| Unique scenario name: Editor toolbar theming & state coherence | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Modal/toast visual system check | PASS | Execution status "**Blocked** – Requires running UI preview; blocked by dependency install failure." uses an approved label. |
+| Unique scenario name: Modal/toast visual system check | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Add Markdown document with live preview | PASS | Execution status "**Blocked** – Test documents cannot be created without functioning preview environment." uses an approved label. |
+| Unique scenario name: Add Markdown document with live preview | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Add HTML document with preview parity | PASS | Execution status "**Blocked** – Preview unavailable; blocked on dependency installation." uses an approved label. |
+| Unique scenario name: Add HTML document with preview parity | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Add PlantUML document preview | PASS | Execution status "**Blocked** – PlantUML renderer assets missing because `node-plantuml` post-install script could not download `viz.js`." uses an approved label. |
+| Unique scenario name: Add PlantUML document preview | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Add PDF document preview | PASS | Execution status "**Blocked** – Preview environment not runnable without build artifacts." uses an approved label. |
+| Unique scenario name: Add PDF document preview | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Add image asset preview (PNG/JPG) | PASS | Execution status "**Blocked** – UI preview build blocked." uses an approved label. |
+| Unique scenario name: Add image asset preview (PNG/JPG) | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Add plaintext document workflow | PASS | Execution status "**Blocked** – Dependent on preview build completion; blocked." uses an approved label. |
+| Unique scenario name: Add plaintext document workflow | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Template preview rendering | PASS | Execution status "**Blocked** – Preview build artifacts unavailable." uses an approved label. |
+| Unique scenario name: Template preview rendering | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Status bar connection messaging | PASS | Execution status "**Blocked** – Cannot verify without running UI." uses an approved label. |
+| Unique scenario name: Status bar connection messaging | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Cross-view iconography audit | PASS | Execution status "**Blocked** – Requires visual inspection of preview build; blocked." uses an approved label. |
+| Unique scenario name: Cross-view iconography audit | PASS | Scenario name is unique within the matrix. |
+| Execution status format: Dark mode typography & contrast check | PASS | Execution status "**Blocked** – UI preview unavailable." uses an approved label. |
+| Unique scenario name: Dark mode typography & contrast check | PASS | Scenario name is unique within the matrix. |
+| Execution status format: High DPI rendering review | PASS | Execution status "**Blocked** – Preview build blocked; cannot execute scenario." uses an approved label. |
+| Unique scenario name: High DPI rendering review | PASS | Scenario name is unique within the matrix. |
+| Markdown document scenario present | PASS | Scenario covering Markdown documents is present. |
+| HTML document scenario present | PASS | Scenario covering HTML documents is present. |
+| PlantUML document scenario present | PASS | Scenario covering PlantUML documents is present. |
+| PDF document scenario present | PASS | Scenario covering PDF documents is present. |
+| Image document scenario present | PASS | Scenario covering PNG documents is present. |
+| Plaintext document scenario present | PASS | Scenario covering plaintext documents is present. |
+| Scenario coverage summary | PASS | Scenario counts — Pass: 0, Fail: 0, Blocked: 18, Not Run: 0. |
+
+**Summary:** Pass 0, Fail 0, Blocked 18, Not Run 0.

--- a/docs/gui-test-plan-report.md
+++ b/docs/gui-test-plan-report.md
@@ -1,0 +1,81 @@
+# GUI Quality Validation Plan and Test Report
+
+## 1. Prioritized Test Scenarios
+
+The following test matrix reflects the current Electron preview experience that runs fully in-browser with a sample workspace. Scenarios focus on the highest risk UX areas that are shippable without a backend. Prioritization considers user impact and the likelihood of regression (P1 = highest).
+
+| Priority | Scenario | Objective | Test Steps | Expected Outcome | Environment | Execution Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| P1 | Application boot and sample workspace load | Verify the renderer initializes, seeds sample data, and shows no blocking errors. | 1. Launch the static preview build. 2. Wait for repository init. 3. Observe sidebar/tree and status bar. | Sample workspace and templates render; no fatal error banner. | Desktop, Chromium 139 (headless), Ubuntu 22.04 | **Blocked** – Preview build cannot be generated because `npm install` fails (node-plantuml requires downloading `viz.js`, which is unreachable in the current offline environment). |
+| P1 | Document creation and autosave persistence | Ensure new documents retain edits across reloads. | 1. Click **Create New Document**. 2. Enter unique text. 3. Reload app. 4. Reopen the created doc. | Edited content persists after reload and tab switch. | Desktop, Chromium 139 (headless), Ubuntu 22.04 | **Blocked** – Depends on successful preview build; prerequisites unavailable. |
+| P1 | Layout responsiveness at critical breakpoints | Validate sidebar and editor adapt between desktop/tablet/phone widths. | 1. Load app at 1280px. 2. Resize to 768px. 3. Resize to 375px. | Navigation remains accessible; editor readable with no clipped content. | Desktop, Chromium 139 & WebKit 17 (headless), Ubuntu 22.04 | **Blocked** – Requires running UI preview; assets not compiled due to dependency install failure. |
+| P1 | Keyboard navigation starting focus | Confirm first focusable element is reachable via keyboard with visible outline. | 1. Load app. 2. Press `Tab` repeatedly. | Focus shifts from the body to search input (or primary CTA) with accessible outline. | Desktop, Chromium 139 (headless), Ubuntu 22.04 | **Blocked** – Preview not available; see environment limitation above. |
+| P1 | Global layout & typography consistency | Validate that typography scale, spacing, and iconography align between sidebar, header, editor, and preview panes. | 1. Capture screenshots of each major panel at 1280px. 2. Compare font sizes, padding, and icon sizes against the design tokens. 3. Toggle between light/dark (if available) to spot mismatches. | Panels use consistent typography scale, grid spacing, and iconography with no stray font fallbacks or misaligned badges. | Desktop, Chromium 139 (headed), Ubuntu 22.04 | **Blocked** – Screenshot capture requires a compiled build; build step failed. |
+| P1 | Editor toolbar theming & state coherence | Ensure toolbar buttons, dropdowns, and toggle states present consistent hover/active/disabled styles. | 1. Hover and click each toolbar control. 2. Toggle split preview modes. 3. Validate tooltip alignment and focus rings. | Toolbar controls exhibit consistent theming, focus outlines, and disabled states across modes. | Desktop, Chromium 139 (headed), Ubuntu 22.04 | **Blocked** – UI cannot be launched without build artifacts. |
+| P1 | Modal/toast visual system check | Validate dialog modals (Refine with AI) and toast notifications (autosave/status) align with design spacing, elevation, and animation. | 1. Trigger Refine modal and autosave toast (mock autosave success). 2. Inspect overlay opacity, shadows, and border radius. 3. Dismiss and confirm motion timing. | Overlays respect spacing tokens, accessible contrast, and close gracefully without layout jumps. | Desktop, Chromium 139 (headed), Ubuntu 22.04 | **Blocked** – Requires running UI preview; blocked by dependency install failure. |
+| P1 | Add Markdown document with live preview | Confirm the default Markdown template saves, renders, and previews correctly. | 1. Create new document (auto .md). 2. Add headings, lists, fenced code, Mermaid block. 3. Save and reload. | Markdown syntax renders in both editor and preview; Mermaid graph displays via renderer after reload. | Desktop, Chromium 139 (headless), Ubuntu 22.04 | **Blocked** – Test documents cannot be created without functioning preview environment. |
+| P1 | Add HTML document with preview parity | Validate HTML documents render in preview panel with sandboxing. | 1. Duplicate template to `.html`. 2. Insert semantic tags, inline styles, script tag. 3. Reload and inspect preview sandbox. | HTML renders with expected styles while scripts stay sandboxed; editor retains syntax highlighting. | Desktop, Chromium 139 (headed), Ubuntu 22.04 | **Blocked** – Preview unavailable; blocked on dependency installation. |
+| P1 | Add PlantUML document preview | Ensure standalone `.puml` diagrams generate renders. | 1. Create new doc named `architecture.puml`. 2. Paste sample diagram. 3. Confirm renderer loads image. | PlantUML preview shows diagram thumbnail; errors surface if syntax invalid. | Desktop, Chromium 139 (headless), Ubuntu 22.04 | **Blocked** – PlantUML renderer assets missing because `node-plantuml` post-install script could not download `viz.js`. |
+| P1 | Add PDF document preview | Validate PDF assets display in preview frame. | 1. Upload/import sample `.pdf`. 2. Open from sidebar. 3. Scroll through pages. | PDF renders with pagination and zoom controls; no console errors. | Desktop, Chromium 139 (headed), Ubuntu 22.04 | **Blocked** – Preview environment not runnable without build artifacts. |
+| P1 | Add image asset preview (PNG/JPG) | Confirm image files render with metadata and scaling controls. | 1. Import sample `.png` and `.jpg`. 2. Open previews. 3. Resize viewport. | Image previews scale responsively, maintain aspect ratio, and show filename metadata. | Desktop, Chromium 139 & WebKit 17 (headed), Ubuntu 22.04 | **Blocked** – UI preview build blocked. |
+| P1 | Add plaintext document workflow | Validate `.txt` documents respect monospace styling and AI tooling limits. | 1. Create new document and set extension `.txt`. 2. Enter long-form text. 3. Trigger AI refine (should be available). | Plaintext uses monospace font, retains soft wrap, and AI actions stay enabled. | Desktop, Chromium 139 (headless), Ubuntu 22.04 | **Blocked** – Dependent on preview build completion; blocked. |
+| P2 | Template preview rendering | Validate template list interactions and visual consistency. | 1. Expand **Templates**. 2. Select **Creative Story Starter**. | Template detail opens with typography intact; destructive actions clearly styled. | Desktop, Chromium 139 (headless), Ubuntu 22.04 | **Blocked** – Preview build artifacts unavailable. |
+| P2 | Status bar connection messaging | Ensure offline/error states surface clearly without blocking editing. | 1. Launch preview build (no providers configured). 2. Observe status bar messaging. | Connection warning displayed with non-blocking styling. | Desktop, Chromium 139 (headless), Ubuntu 22.04 | **Blocked** – Cannot verify without running UI. |
+| P2 | Cross-view iconography audit | Confirm icons in sidebar, toolbar, context menus, and status bar use the same library weights and alignment. | 1. Compare icons across views at 1x and 2x zoom. 2. Inspect pixel alignment via dev tools grid. | Icons render crisply with consistent stroke weight and alignment; no off-brand glyphs. | Desktop, Chromium 139 (headed), Ubuntu 22.04 | **Blocked** – Requires visual inspection of preview build; blocked. |
+| P2 | Dark mode typography & contrast check | Validate dark theme color tokens preserve contrast ratios. | 1. Toggle dark theme. 2. Inspect headings, body copy, and syntax tokens. 3. Run axe contrast checks. | Text contrast meets WCAG AA; syntax highlighting remains legible. | Desktop, Chromium 139 (headed), Ubuntu 22.04 | **Blocked** – UI preview unavailable. |
+| P3 | High DPI rendering review | Ensure UI scales gracefully on 200% zoom / retina displays. | 1. Set device pixel ratio to 2. 2. Inspect key components for blurriness. | Text, icons, and previews remain sharp; no bitmap scaling artifacts. | Desktop, Chromium 139 (headed), Ubuntu 22.04 | **Blocked** – Preview build blocked; cannot execute scenario. |
+
+## 2. Test Execution Report
+
+### 2.1 Execution Summary
+
+| Activity | Result |
+| --- | --- |
+| `npm test` | **Pass** – `scripts/validate-gui-test-plan.mjs` parsed the GUI test plan, verified section coverage, and confirmed that every scenario row carries an approved execution status label. Result artifacts are stored in `artifacts/gui-test-plan-validation.*`. |
+| `npm install` | **Failed** – `node-plantuml` post-install script attempted to download `viz.js` from the public internet. The sandboxed environment has no outbound network access, causing an `ENETUNREACH` error and aborting dependency installation. 【90d68e†L1-L28】 |
+| `npm run build` | **Blocked** – Build depends on Tailwind CLI and bundled assets generated by `npm install`. Because dependencies were not installed, the CLI is unavailable and the build cannot progress. 【f5260c†L1-L11】 |
+| GUI scenario execution | **Blocked** – All manual and automated GUI flows listed in Section&nbsp;1 require the preview bundle produced by the build pipeline. Without dependencies and build artifacts, the application cannot be launched for testing. |
+
+### 2.2 Impact on Scenario Coverage
+
+- No scenarios in Section&nbsp;1 could be executed during this cycle. Every entry remains in a **Blocked** state and will require a rerun once dependency installation succeeds. The new documentation validation harness (see `npm test` above) ensures the matrix structure is kept current while we work to unblock the UI build.
+- Historical bug evidence from earlier runs (autosave loss, mobile layout clipping, keyboard focus trap) has not been revalidated in this execution. Prior findings remain open and unverified.
+
+### 2.3 Blocker Detail
+
+- The `node-plantuml` package’s install script falls back to downloading `viz.js` when Graphviz binaries are absent. In offline CI environments, this results in an `ENETUNREACH` socket error. A local mirror or stubbed renderer is required to proceed.
+- Because dependency installation aborted, the Tailwind CLI binary (`node_modules/.bin/tailwindcss`) is absent. As a result, `npm run build` terminates immediately when attempting to invoke Tailwind.
+
+### 2.4 Mitigation Plan
+
+1. Provide the `viz.js` artifact locally (check it into the repository or host it on an internal mirror) and configure `node-plantuml` to consume the offline asset so `npm install` can succeed in sandboxed CI.
+2. Alternatively, stub or remove PlantUML integration for web-preview-only builds to avoid the network-dependent install script during documentation/test runs.
+3. After addressing dependency installation, re-run `npm install`, `npm run build`, and the full GUI scenario suite to collect pass/fail evidence and screenshots.
+
+### 2.5 Current Bug & Recommendation Status
+
+| ID | Original Severity | Last Confirmed State | Notes |
+| --- | --- | --- | --- |
+| BUG-01 | Critical | Not re-tested | Awaiting rebuilt environment to verify whether autosave regression persists. |
+| BUG-02 | High | Not re-tested | Requires responsive viewport checks once preview build is available. |
+| BUG-03 | High | Not re-tested | Needs renewed keyboard navigation sweep when UI can load. |
+
+### 2.6 Usability and Reliability Backlog
+
+- Previously logged UX improvements (autosave confirmations, mobile navigation drawer, connection badge guidance, shortcut hints) remain outstanding; execution is paused until the environment issue is resolved.
+
+### 2.7 Coverage Gaps and Next Steps
+
+- **Coverage Achieved**: None this cycle due to build blocking issues.
+- **Immediate Gaps**: All GUI validations, accessibility sweeps, and file-type onboarding scenarios are pending execution. Additionally, smoke build validation is blocked.
+- **Next Steps**: Unblock dependency installation, regenerate build artifacts, then re-run the prioritized suite. Once executed, capture evidence and refresh Sections&nbsp;2.1–2.6 with results, defect updates, and screenshots.
+- **Next Steps**: Unblock dependency installation, regenerate build artifacts, then re-run the prioritized suite. Once executed, capture evidence and refresh Sections&nbsp;2.1–2.6 with results, defect updates, and screenshots. Continue running the markdown validation script (`npm test`) in CI to ensure the expanded plan stays aligned with execution evidence.
+
+### 2.8 Future Testing Strategy Recommendations (unchanged)
+
+1. Automate core flows (create/edit/save, template preview) with Playwright plus visual assertions to guard against regressions.
+2. Integrate axe-core accessibility scans and manual screen reader smoke tests into CI to enforce WCAG compliance.
+3. Add responsive snapshot testing for critical breakpoints (desktop, tablet, mobile) to catch layout regressions early.
+4. Expand manual testing to include touch devices and configurable AI providers to verify the status bar error clears correctly.
+5. Implement fault-injection tests (mocked network/service failures) to validate error modals and recovery UX.
+6. Build a shared fixture library and Playwright coverage for all supported file types (Markdown, HTML, PlantUML, PDF, PNG/JPG, plaintext) to prevent regression in document onboarding and preview rendering.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "package": "npm run build && electron-builder",
     "publish": "npm run build && electron-builder --publish always",
     "prepare:icons": "node scripts/prepare-icons.mjs",
+    "test": "node scripts/validate-gui-test-plan.mjs",
     "postinstall": "electron-builder install-app-deps",
     "build:css": "tailwindcss -i ./styles/tailwind.css -o ./dist/tailwind.css --minify",
     "dev:web": "npm run build && http-server -c-1 -p 4173 ."

--- a/scripts/validate-gui-test-plan.mjs
+++ b/scripts/validate-gui-test-plan.mjs
@@ -1,0 +1,303 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const projectRoot = path.resolve(new URL('.', import.meta.url).pathname, '..');
+const docPath = path.resolve(projectRoot, 'docs', 'gui-test-plan-report.md');
+const artifactDir = path.resolve(projectRoot, 'artifacts');
+
+function ensureArtifactsDir() {
+  if (!fs.existsSync(artifactDir)) {
+    fs.mkdirSync(artifactDir, { recursive: true });
+  }
+}
+
+function readDocument() {
+  try {
+    return fs.readFileSync(docPath, 'utf8');
+  } catch (error) {
+    throw new Error(`Unable to read ${path.relative(projectRoot, docPath)}: ${error.message}`);
+  }
+}
+
+function extractScenarioTable(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const headerIndex = lines.findIndex((line) => line.trim().startsWith('| Priority'));
+  if (headerIndex === -1) {
+    throw new Error('Scenario table header not found in Section 1.');
+  }
+  const rows = [];
+  for (let i = headerIndex + 2; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trim()) {
+      break;
+    }
+    if (line.trim().startsWith('|')) {
+      rows.push(line);
+    }
+  }
+  if (rows.length === 0) {
+    throw new Error('Scenario table does not contain any rows.');
+  }
+  return rows;
+}
+
+function parseScenarioRow(row) {
+  const cells = row
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+  if (cells.length < 7) {
+    throw new Error(`Scenario row has an unexpected number of columns: ${row}`);
+  }
+  return {
+    priority: cells[0],
+    scenario: cells[1],
+    objective: cells[2],
+    testSteps: cells[3],
+    expectedOutcome: cells[4],
+    environment: cells[5],
+    executionStatus: cells[6],
+    raw: row,
+  };
+}
+
+function validateExecutionStatus(status) {
+  const allowed = ['**Pass**', '**Fail**', '**Blocked**', '**Not Run**'];
+  return allowed.some((token) => status.includes(token));
+}
+
+function collectValidations(markdown) {
+  const validations = [];
+  const failures = [];
+
+  const requiredHeadings = [
+    '## 1. Prioritized Test Scenarios',
+    '## 2. Test Execution Report',
+    '### 2.1 Execution Summary',
+    '### 2.2 Impact on Scenario Coverage',
+    '### 2.3 Blocker Detail',
+    '### 2.4 Mitigation Plan',
+  ];
+
+  requiredHeadings.forEach((heading) => {
+    const found = markdown.includes(heading);
+    validations.push({
+      name: `Heading present: ${heading}`,
+      status: found ? 'pass' : 'fail',
+      details: found
+        ? 'Heading located in document.'
+        : 'Heading missing from document. Update the test report to include this section.',
+    });
+    if (!found) {
+      failures.push(`Missing heading: ${heading}`);
+    }
+  });
+
+  const rows = extractScenarioTable(markdown).map(parseScenarioRow);
+
+  const seenNames = new Set();
+  rows.forEach((row) => {
+    const statusValid = validateExecutionStatus(row.executionStatus);
+    validations.push({
+      name: `Execution status format: ${row.scenario}`,
+      status: statusValid ? 'pass' : 'fail',
+      details: statusValid
+        ? `Execution status "${row.executionStatus}" uses an approved label.`
+        : 'Execution status must include one of **Pass**, **Fail**, **Blocked**, or **Not Run**.',
+    });
+    if (!statusValid) {
+      failures.push(`Invalid execution status for scenario: ${row.scenario}`);
+    }
+
+    if (seenNames.has(row.scenario)) {
+      validations.push({
+        name: `Unique scenario name: ${row.scenario}`,
+        status: 'fail',
+        details: 'Duplicate scenario name detected. Scenario names must be unique.',
+      });
+      failures.push(`Duplicate scenario name found: ${row.scenario}`);
+    } else {
+      seenNames.add(row.scenario);
+      validations.push({
+        name: `Unique scenario name: ${row.scenario}`,
+        status: 'pass',
+        details: 'Scenario name is unique within the matrix.',
+      });
+    }
+  });
+
+  const fileTypeExpectations = [
+    { keyword: 'Markdown', label: 'Markdown document scenario present' },
+    { keyword: 'HTML', label: 'HTML document scenario present' },
+    { keyword: 'PlantUML', label: 'PlantUML document scenario present' },
+    { keyword: 'PDF', label: 'PDF document scenario present' },
+    { keyword: 'PNG', label: 'Image document scenario present' },
+    { keyword: 'plaintext', label: 'Plaintext document scenario present' },
+  ];
+
+  fileTypeExpectations.forEach(({ keyword, label }) => {
+    const match = rows.some((row) => row.scenario.toLowerCase().includes(keyword.toLowerCase()));
+    validations.push({
+      name: label,
+      status: match ? 'pass' : 'fail',
+      details: match
+        ? `Scenario covering ${keyword} documents is present.`
+        : `Add a scenario that covers ${keyword} documents to satisfy onboarding coverage.`,
+    });
+    if (!match) {
+      failures.push(`Missing file type scenario: ${keyword}`);
+    }
+  });
+
+  const statusCounts = rows.reduce(
+    (acc, row) => {
+      if (row.executionStatus.includes('**Pass**')) acc.pass += 1;
+      else if (row.executionStatus.includes('**Fail**')) acc.fail += 1;
+      else if (row.executionStatus.includes('**Blocked**')) acc.blocked += 1;
+      else if (row.executionStatus.includes('**Not Run**')) acc.notRun += 1;
+      return acc;
+    },
+    { pass: 0, fail: 0, blocked: 0, notRun: 0 },
+  );
+
+  validations.push({
+    name: 'Scenario coverage summary',
+    status: 'pass',
+    details: `Scenario counts — Pass: ${statusCounts.pass}, Fail: ${statusCounts.fail}, Blocked: ${statusCounts.blocked}, Not Run: ${statusCounts.notRun}.`,
+  });
+
+  return { validations, failures, statusCounts };
+}
+
+function writeArtifacts(result) {
+  ensureArtifactsDir();
+  const timestamp = new Date().toISOString();
+  const payload = { timestamp, ...result };
+  fs.writeFileSync(
+    path.resolve(artifactDir, 'gui-test-plan-validation.json'),
+    `${JSON.stringify(payload, null, 2)}\n`,
+    'utf8',
+  );
+
+  const markdownLines = [
+    '# GUI Test Plan Validation Results',
+    '',
+    `Generated: ${timestamp}`,
+    '',
+    '| Test | Status | Details |',
+    '| --- | --- | --- |',
+    ...result.validations.map((test) => `| ${test.name} | ${test.status.toUpperCase()} | ${test.details} |`),
+    '',
+    `**Summary:** Pass ${result.statusCounts.pass}, Fail ${result.statusCounts.fail}, Blocked ${result.statusCounts.blocked}, Not Run ${result.statusCounts.notRun}.`,
+  ];
+
+  fs.writeFileSync(
+    path.resolve(artifactDir, 'gui-test-plan-validation.md'),
+    `${markdownLines.join('\n')}\n`,
+    'utf8',
+  );
+
+  const htmlRows = result.validations
+    .map((test) => {
+      const statusClass = test.status === 'pass' ? 'pass' : test.status === 'fail' ? 'fail' : 'info';
+      return `<tr class="${statusClass}"><td>${test.name}</td><td>${test.status.toUpperCase()}</td><td>${test.details}</td></tr>`;
+    })
+    .join('\n');
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>GUI Test Plan Validation Results</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  }
+  body {
+    margin: 2rem;
+    background: #f6f7fb;
+    color: #1f2933;
+  }
+  h1 {
+    font-size: 1.8rem;
+    margin-bottom: 1rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #ffffff;
+    box-shadow: 0 1px 4px rgba(15, 23, 42, 0.12);
+  }
+  th, td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: top;
+  }
+  th {
+    background: #1f2937;
+    color: #f9fafb;
+    text-align: left;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+  tr.pass td.status {
+    color: #047857;
+    font-weight: 600;
+  }
+  tr.fail td.status {
+    color: #b91c1c;
+    font-weight: 600;
+  }
+  tr.info td.status {
+    color: #0f172a;
+    font-weight: 600;
+  }
+  tr:nth-child(even) td {
+    background: rgba(15, 23, 42, 0.03);
+  }
+  .meta {
+    margin-bottom: 1rem;
+    color: #4b5563;
+  }
+</style>
+</head>
+<body>
+  <h1>GUI Test Plan Validation Results</h1>
+  <p class="meta">Generated: ${timestamp}</p>
+  <table>
+    <thead>
+      <tr><th>Test</th><th>Status</th><th>Details</th></tr>
+    </thead>
+    <tbody>
+      ${htmlRows}
+      <tr class="info"><td colspan="3"><strong>Summary:</strong> Pass ${result.statusCounts.pass}, Fail ${result.statusCounts.fail}, Blocked ${result.statusCounts.blocked}, Not Run ${result.statusCounts.notRun}</td></tr>
+    </tbody>
+  </table>
+</body>
+</html>`;
+
+  fs.writeFileSync(
+    path.resolve(artifactDir, 'gui-test-plan-validation.html'),
+    html,
+    'utf8',
+  );
+}
+
+function main() {
+  const markdown = readDocument();
+  const result = collectValidations(markdown);
+  writeArtifacts(result);
+  const failed = result.failures.length > 0;
+  result.validations.forEach((test) => {
+    const icon = test.status === 'pass' ? '✅' : test.status === 'fail' ? '❌' : 'ℹ️';
+    console.log(`${icon} ${test.name} — ${test.details}`);
+  });
+  console.log('\nSummary:', result.statusCounts);
+  if (failed) {
+    console.error('\nValidation failures detected. See artifacts/gui-test-plan-validation.json for details.');
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a node-based validation harness for the GUI test plan and expose it via `npm test`
- commit the generated validation artifacts to share the executed results and evidence
- update the GUI test report with the new automation run and guidance for keeping the matrix current while the UI build is blocked

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e165f3800083328c5740b3b49fc532