### PR TITLE
Shorten image language label

### DIFF
--- a/services/languageService.ts
+++ b/services/languageService.ts
@@ -23,7 +23,7 @@ export const SUPPORTED_LANGUAGES = [
     { id: 'pascal', label: 'Pascal' },
     { id: 'ini', label: 'INI' },
     { id: 'pdf', label: 'PDF' },
-    { id: 'image', label: 'Image (PNG/JPEG/GIF/WebP/SVG/BMP)' },
+    { id: 'image', label: 'Image' },
 ];
 
 export const mapExtensionToLanguageId = (extension: string | null): string => {


### PR DESCRIPTION
## Summary
- shorten the image language label in the dropdown to "Image" to reduce width

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3e86d85d88332a6bae7cd76b5454c