### PR TITLE
Highlight open tabs in the sidebar tree

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1894,6 +1894,7 @@ const MainApp: React.FC = () => {
                                         lastClickedId={lastClickedId}
                                         setLastClickedId={setLastClickedId}
                                         activeNodeId={activeNodeId}
+                                        openDocumentIds={openDocumentIds}
                                         onSelectNode={handleSelectNode}
                                         onDeleteSelection={handleDeleteSelection}
                                         onDeleteNode={handleDeleteNode}

--- a/components/PromptList.tsx
+++ b/components/PromptList.tsx
@@ -10,6 +10,7 @@ interface DocumentListProps {
   focusedItemId: string | null;
   indentPerLevel: number;
   verticalSpacing: number;
+  openDocumentIds: Set<string>;
   onSelectNode: (id: string, e: React.MouseEvent) => void;
   onDeleteNode: (id: string, shiftKey?: boolean) => void;
   onRenameNode: (id: string, newTitle: string) => void;
@@ -33,6 +34,7 @@ const DocumentList: React.FC<DocumentListProps> = ({
   focusedItemId,
   indentPerLevel,
   verticalSpacing,
+  openDocumentIds,
   onSelectNode,
   onDeleteNode,
   onRenameNode,
@@ -124,6 +126,7 @@ const DocumentList: React.FC<DocumentListProps> = ({
                 level={0}
                 indentPerLevel={indentPerLevel}
                 verticalSpacing={verticalSpacing}
+                openDocumentIds={openDocumentIds}
                 selectedIds={selectedIds}
                 focusedItemId={focusedItemId}
                 expandedIds={displayExpandedIds}

--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -13,6 +13,7 @@ interface DocumentTreeItemProps {
   level: number;
   indentPerLevel: number;
   verticalSpacing: number;
+  openDocumentIds: Set<string>;
   selectedIds: Set<string>;
   focusedItemId: string | null;
   expandedIds: Set<string>;
@@ -103,6 +104,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
     indentPerLevel,
     verticalSpacing,
     searchTerm,
+    openDocumentIds,
   } = props;
   
   const [isRenaming, setIsRenaming] = useState(false);
@@ -117,6 +119,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
   const isExpanded = expandedIds.has(node.id);
   const isFolder = node.type === 'folder';
   const isCodeFile = node.doc_type === 'source_code';
+  const isOpenInTab = !isFolder && openDocumentIds.has(node.id);
   
   useEffect(() => {
     if (renamingNodeId === node.id) {
@@ -245,11 +248,20 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
                     <div className="w-4" /> // Spacer for alignment
                 )}
 
-                {isFolder ? (
-                    isExpanded ? <FolderOpenIcon className="w-3.5 h-3.5 flex-shrink-0" /> : <FolderIcon className="w-3.5 h-3.5 flex-shrink-0" />
-                ) : (
-                    isCodeFile ? <CodeIcon className="w-3.5 h-3.5 flex-shrink-0" /> : <FileIcon className="w-3.5 h-3.5 flex-shrink-0" />
-                )}
+                <div className="relative flex-shrink-0">
+                    {isFolder ? (
+                        isExpanded ? <FolderOpenIcon className="w-3.5 h-3.5 flex-shrink-0" /> : <FolderIcon className="w-3.5 h-3.5 flex-shrink-0" />
+                    ) : (
+                        isCodeFile ? <CodeIcon className="w-3.5 h-3.5 flex-shrink-0" /> : <FileIcon className="w-3.5 h-3.5 flex-shrink-0" />
+                    )}
+                    {isOpenInTab && (
+                        <span
+                            className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-primary border border-border-color shadow-sm"
+                            aria-hidden="true"
+                            title="Open in tab"
+                        />
+                    )}
+                </div>
 
                 {isRenaming ? (
                     <input

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -21,6 +21,7 @@ interface SidebarProps {
   lastClickedId: string | null;
   setLastClickedId: React.Dispatch<React.SetStateAction<string | null>>;
   activeNodeId: string | null;
+  openDocumentIds: string[];
   onSelectNode: (id: string, e: React.MouseEvent) => void;
   onDeleteSelection: (ids: Set<string>, options?: { force?: boolean }) => void;
   onDeleteNode: (id: string, shiftKey?: boolean) => void;
@@ -78,6 +79,8 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
   const [isTemplatesCollapsed, setIsTemplatesCollapsed] = useState(false);
   const [templatesPanelHeight, setTemplatesPanelHeight] = useState(DEFAULT_TEMPLATES_PANEL_HEIGHT);
   const { addLog } = useLogger();
+
+  const openDocumentIds = useMemo(() => new Set(props.openDocumentIds), [props.openDocumentIds]);
 
 
   const sidebarRef = useRef<HTMLDivElement>(null);
@@ -369,6 +372,7 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
                     focusedItemId={focusedItemId}
                     indentPerLevel={props.documentTreeIndent}
                     verticalSpacing={props.documentTreeVerticalSpacing}
+                    openDocumentIds={openDocumentIds}
                     onSelectNode={props.onSelectNode}
                     onDeleteNode={props.onDeleteNode}
                     onRenameNode={props.onRenameNode}


### PR DESCRIPTION
## Summary
- pass the list of open document IDs into the sidebar tree
- render a badge on document icons to show when they are opened in tabs

## Testing
- npm run build *(fails: tailwindcss CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e8e2d3b88332aecc604ecab04c28