### PR TITLE
Highlight open tabs in document tree

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -134,6 +134,7 @@ const MainApp: React.FC = () => {
 
     const activeNodeId = tabState.activeId;
     const openDocumentIds = tabState.order;
+    const openDocumentIdsSet = useMemo(() => new Set(openDocumentIds), [openDocumentIds]);
 
     const activateDocumentTab = useCallback((documentId: string) => {
         setTabState(prev => {
@@ -1894,6 +1895,7 @@ const MainApp: React.FC = () => {
                                         lastClickedId={lastClickedId}
                                         setLastClickedId={setLastClickedId}
                                         activeNodeId={activeNodeId}
+                                        openDocumentIds={openDocumentIdsSet}
                                         onSelectNode={handleSelectNode}
                                         onDeleteSelection={handleDeleteSelection}
                                         onDeleteNode={handleDeleteNode}

--- a/components/PromptList.tsx
+++ b/components/PromptList.tsx
@@ -8,6 +8,7 @@ interface DocumentListProps {
   documents: DocumentOrFolder[]; // needed for the empty state check
   selectedIds: Set<string>;
   focusedItemId: string | null;
+  openDocumentIds: Set<string>;
   indentPerLevel: number;
   verticalSpacing: number;
   onSelectNode: (id: string, e: React.MouseEvent) => void;
@@ -31,6 +32,7 @@ const DocumentList: React.FC<DocumentListProps> = ({
   documents,
   selectedIds,
   focusedItemId,
+  openDocumentIds,
   indentPerLevel,
   verticalSpacing,
   onSelectNode,
@@ -127,6 +129,7 @@ const DocumentList: React.FC<DocumentListProps> = ({
                 selectedIds={selectedIds}
                 focusedItemId={focusedItemId}
                 expandedIds={displayExpandedIds}
+                openDocumentIds={openDocumentIds}
                 onSelectNode={onSelectNode}
                 onDeleteNode={onDeleteNode}
                 onRenameNode={onRenameNode}

--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -16,6 +16,7 @@ interface DocumentTreeItemProps {
   selectedIds: Set<string>;
   focusedItemId: string | null;
   expandedIds: Set<string>;
+  openDocumentIds: Set<string>;
   onSelectNode: (id: string, e: React.MouseEvent) => void;
   onDeleteNode: (id: string, shiftKey: boolean) => void;
   onRenameNode: (id: string, newTitle: string) => void;
@@ -86,6 +87,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
     selectedIds,
     focusedItemId,
     expandedIds,
+    openDocumentIds,
     onSelectNode,
     onDeleteNode,
     onRenameNode,
@@ -117,6 +119,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
   const isExpanded = expandedIds.has(node.id);
   const isFolder = node.type === 'folder';
   const isCodeFile = node.doc_type === 'source_code';
+  const isOpenInTab = !isFolder && openDocumentIds.has(node.id);
   
   useEffect(() => {
     if (renamingNodeId === node.id) {
@@ -245,11 +248,23 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
                     <div className="w-4" /> // Spacer for alignment
                 )}
 
-                {isFolder ? (
-                    isExpanded ? <FolderOpenIcon className="w-3.5 h-3.5 flex-shrink-0" /> : <FolderIcon className="w-3.5 h-3.5 flex-shrink-0" />
-                ) : (
-                    isCodeFile ? <CodeIcon className="w-3.5 h-3.5 flex-shrink-0" /> : <FileIcon className="w-3.5 h-3.5 flex-shrink-0" />
-                )}
+                <div className="relative flex-shrink-0">
+                    {isFolder ? (
+                        isExpanded ? <FolderOpenIcon className="w-3.5 h-3.5" /> : <FolderIcon className="w-3.5 h-3.5" />
+                    ) : (
+                        isCodeFile ? <CodeIcon className="w-3.5 h-3.5" /> : <FileIcon className="w-3.5 h-3.5" />
+                    )}
+                    {isOpenInTab && (
+                        <>
+                            <span
+                                className="absolute -top-1 -right-1 w-1.5 h-1.5 rounded-full bg-primary border border-secondary"
+                                title="Open in tab"
+                                aria-hidden="true"
+                            />
+                            <span className="sr-only">Open in tab</span>
+                        </>
+                    )}
+                </div>
 
                 {isRenaming ? (
                     <input

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -21,6 +21,7 @@ interface SidebarProps {
   lastClickedId: string | null;
   setLastClickedId: React.Dispatch<React.SetStateAction<string | null>>;
   activeNodeId: string | null;
+  openDocumentIds: Set<string>;
   onSelectNode: (id: string, e: React.MouseEvent) => void;
   onDeleteSelection: (ids: Set<string>, options?: { force?: boolean }) => void;
   onDeleteNode: (id: string, shiftKey?: boolean) => void;
@@ -367,6 +368,7 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
                     documents={props.documents}
                     selectedIds={props.selectedIds}
                     focusedItemId={focusedItemId}
+                    openDocumentIds={props.openDocumentIds}
                     indentPerLevel={props.documentTreeIndent}
                     verticalSpacing={props.documentTreeVerticalSpacing}
                     onSelectNode={props.onSelectNode}


### PR DESCRIPTION
## Summary
- propagate the list of open document IDs into the sidebar tree
- add an indicator on document items to show when they are open in a tab
- memoize the open tab ID set for efficient lookups

## Testing
- npm run build *(fails: tailwindcss CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e8e2d3b88332aecc604ecab04c28