### PR TITLE
Highlight open documents in treeview

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1910,6 +1910,7 @@ const MainApp: React.FC = () => {
                                         onToggleExpand={handleToggleExpand}
                                         onExpandAll={handleExpandAll}
                                         onCollapseAll={handleCollapseAll}
+                                        openDocumentIds={openDocumentIds}
                                         searchTerm={searchTerm}
                                         setSearchTerm={setSearchTerm}
                                         onContextMenu={handleContextMenu}

--- a/components/PromptList.tsx
+++ b/components/PromptList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 // Fix: Correctly import the DocumentOrFolder type.
 import type { DocumentOrFolder } from '../types';
 import DocumentTreeItem, { DocumentNode } from './PromptTreeItem';
@@ -10,6 +10,7 @@ interface DocumentListProps {
   focusedItemId: string | null;
   indentPerLevel: number;
   verticalSpacing: number;
+  openDocumentIds: string[];
   onSelectNode: (id: string, e: React.MouseEvent) => void;
   onDeleteNode: (id: string, shiftKey?: boolean) => void;
   onRenameNode: (id: string, newTitle: string) => void;
@@ -33,6 +34,7 @@ const DocumentList: React.FC<DocumentListProps> = ({
   focusedItemId,
   indentPerLevel,
   verticalSpacing,
+  openDocumentIds,
   onSelectNode,
   onDeleteNode,
   onRenameNode,
@@ -50,6 +52,7 @@ const DocumentList: React.FC<DocumentListProps> = ({
 }) => {
   // Fix: Corrected useState declaration syntax from `=>` to `=`. This resolves all subsequent "cannot find name" errors.
   const [isRootDropping, setIsRootDropping] = useState(false);
+  const openDocumentIdSet = useMemo(() => new Set(openDocumentIds), [openDocumentIds]);
   
   const handleRootDrop = (e: React.DragEvent) => {
     e.preventDefault();
@@ -124,6 +127,7 @@ const DocumentList: React.FC<DocumentListProps> = ({
                 level={0}
                 indentPerLevel={indentPerLevel}
                 verticalSpacing={verticalSpacing}
+                openDocumentIds={openDocumentIdSet}
                 selectedIds={selectedIds}
                 focusedItemId={focusedItemId}
                 expandedIds={displayExpandedIds}

--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -13,6 +13,7 @@ interface DocumentTreeItemProps {
   level: number;
   indentPerLevel: number;
   verticalSpacing: number;
+  openDocumentIds: Set<string>;
   selectedIds: Set<string>;
   focusedItemId: string | null;
   expandedIds: Set<string>;
@@ -86,6 +87,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
     selectedIds,
     focusedItemId,
     expandedIds,
+    openDocumentIds,
     onSelectNode,
     onDeleteNode,
     onRenameNode,
@@ -117,6 +119,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
   const isExpanded = expandedIds.has(node.id);
   const isFolder = node.type === 'folder';
   const isCodeFile = node.doc_type === 'source_code';
+  const isOpenInTab = !isFolder && openDocumentIds.has(node.id);
   
   useEffect(() => {
     if (renamingNodeId === node.id) {
@@ -250,6 +253,13 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
                 ) : (
                     isCodeFile ? <CodeIcon className="w-3.5 h-3.5 flex-shrink-0" /> : <FileIcon className="w-3.5 h-3.5 flex-shrink-0" />
                 )}
+                {isOpenInTab && (
+                    <span
+                        className="w-1.5 h-1.5 rounded-full bg-primary flex-shrink-0"
+                        aria-hidden="true"
+                        title="Open in tab"
+                    />
+                )}
 
                 {isRenaming ? (
                     <input
@@ -315,6 +325,7 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
                         verticalSpacing={verticalSpacing}
                         canMoveUp={index > 0}
                         canMoveDown={index < node.children.length - 1}
+                        openDocumentIds={openDocumentIds}
                     />
                 ))}
             </ul>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -37,6 +37,7 @@ interface SidebarProps {
   onToggleExpand: (id: string) => void;
   onExpandAll: () => void;
   onCollapseAll: () => void;
+  openDocumentIds: string[];
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   onContextMenu: (e: React.MouseEvent, nodeId: string | null) => void;
@@ -73,7 +74,7 @@ const findNodeAndSiblings = (nodes: DocumentNode[], id: string): {node: Document
 };
 
 const Sidebar: React.FC<SidebarProps> = (props) => {
-  const { documentTree, navigableItems, searchTerm, setSearchTerm, setSelectedIds, lastClickedId, setLastClickedId, onContextMenu, renamingNodeId, onRenameComplete, onExpandAll, onCollapseAll, commands, pendingRevealId, onRevealHandled } = props;
+  const { documentTree, navigableItems, searchTerm, setSearchTerm, setSelectedIds, lastClickedId, setLastClickedId, onContextMenu, renamingNodeId, onRenameComplete, onExpandAll, onCollapseAll, commands, pendingRevealId, onRevealHandled, openDocumentIds } = props;
   const [focusedItemId, setFocusedItemId] = useState<string | null>(null);
   const [isTemplatesCollapsed, setIsTemplatesCollapsed] = useState(false);
   const [templatesPanelHeight, setTemplatesPanelHeight] = useState(DEFAULT_TEMPLATES_PANEL_HEIGHT);
@@ -369,6 +370,7 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
                     focusedItemId={focusedItemId}
                     indentPerLevel={props.documentTreeIndent}
                     verticalSpacing={props.documentTreeVerticalSpacing}
+                    openDocumentIds={openDocumentIds}
                     onSelectNode={props.onSelectNode}
                     onDeleteNode={props.onDeleteNode}
                     onRenameNode={props.onRenameNode}


### PR DESCRIPTION
## Summary
- pass the set of open document ids down to the tree view items
- show a small primary-colored indicator beside any document that is currently open in a tab

## Testing
- npm run build *(fails: tailwindcss binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e8e2d3b88332aecc604ecab04c28