### PR TITLE
Highlight open documents in treeview

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1894,6 +1894,8 @@ const MainApp: React.FC = () => {
                                         lastClickedId={lastClickedId}
                                         setLastClickedId={setLastClickedId}
                                         activeNodeId={activeNodeId}
+                                        activeDocumentId={activeDocumentId}
+                                        openDocumentIds={openDocumentIds}
                                         onSelectNode={handleSelectNode}
                                         onDeleteSelection={handleDeleteSelection}
                                         onDeleteNode={handleDeleteNode}

--- a/components/PromptList.tsx
+++ b/components/PromptList.tsx
@@ -10,6 +10,8 @@ interface DocumentListProps {
   focusedItemId: string | null;
   indentPerLevel: number;
   verticalSpacing: number;
+  openDocumentIds: Set<string>;
+  activeDocumentId: string | null;
   onSelectNode: (id: string, e: React.MouseEvent) => void;
   onDeleteNode: (id: string, shiftKey?: boolean) => void;
   onRenameNode: (id: string, newTitle: string) => void;
@@ -33,6 +35,8 @@ const DocumentList: React.FC<DocumentListProps> = ({
   focusedItemId,
   indentPerLevel,
   verticalSpacing,
+  openDocumentIds,
+  activeDocumentId,
   onSelectNode,
   onDeleteNode,
   onRenameNode,
@@ -124,6 +128,8 @@ const DocumentList: React.FC<DocumentListProps> = ({
                 level={0}
                 indentPerLevel={indentPerLevel}
                 verticalSpacing={verticalSpacing}
+                openDocumentIds={openDocumentIds}
+                activeDocumentId={activeDocumentId}
                 selectedIds={selectedIds}
                 focusedItemId={focusedItemId}
                 expandedIds={displayExpandedIds}

--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -16,6 +16,8 @@ interface DocumentTreeItemProps {
   selectedIds: Set<string>;
   focusedItemId: string | null;
   expandedIds: Set<string>;
+  openDocumentIds: Set<string>;
+  activeDocumentId: string | null;
   onSelectNode: (id: string, e: React.MouseEvent) => void;
   onDeleteNode: (id: string, shiftKey: boolean) => void;
   onRenameNode: (id: string, newTitle: string) => void;
@@ -86,6 +88,8 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
     selectedIds,
     focusedItemId,
     expandedIds,
+    openDocumentIds,
+    activeDocumentId,
     onSelectNode,
     onDeleteNode,
     onRenameNode,
@@ -117,6 +121,8 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
   const isExpanded = expandedIds.has(node.id);
   const isFolder = node.type === 'folder';
   const isCodeFile = node.doc_type === 'source_code';
+  const isOpenInTab = !isFolder && openDocumentIds.has(node.id);
+  const isActiveTab = isOpenInTab && activeDocumentId === node.id;
   
   useEffect(() => {
     if (renamingNodeId === node.id) {
@@ -251,6 +257,13 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
                     isCodeFile ? <CodeIcon className="w-3.5 h-3.5 flex-shrink-0" /> : <FileIcon className="w-3.5 h-3.5 flex-shrink-0" />
                 )}
 
+                {isOpenInTab && (
+                    <span
+                        aria-hidden="true"
+                        className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${isActiveTab ? 'bg-primary' : 'bg-primary/50'}`}
+                    />
+                )}
+
                 {isRenaming ? (
                     <input
                         ref={renameInputRef}
@@ -313,6 +326,8 @@ const DocumentTreeItem: React.FC<DocumentTreeItemProps> = (props) => {
                         level={level + 1}
                         indentPerLevel={indentPerLevel}
                         verticalSpacing={verticalSpacing}
+                        openDocumentIds={openDocumentIds}
+                        activeDocumentId={activeDocumentId}
                         canMoveUp={index > 0}
                         canMoveDown={index < node.children.length - 1}
                     />

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -21,6 +21,8 @@ interface SidebarProps {
   lastClickedId: string | null;
   setLastClickedId: React.Dispatch<React.SetStateAction<string | null>>;
   activeNodeId: string | null;
+  activeDocumentId: string | null;
+  openDocumentIds: string[];
   onSelectNode: (id: string, e: React.MouseEvent) => void;
   onDeleteSelection: (ids: Set<string>, options?: { force?: boolean }) => void;
   onDeleteNode: (id: string, shiftKey?: boolean) => void;
@@ -78,6 +80,8 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
   const [isTemplatesCollapsed, setIsTemplatesCollapsed] = useState(false);
   const [templatesPanelHeight, setTemplatesPanelHeight] = useState(DEFAULT_TEMPLATES_PANEL_HEIGHT);
   const { addLog } = useLogger();
+
+  const openDocumentIdSet = useMemo(() => new Set(props.openDocumentIds), [props.openDocumentIds]);
 
 
   const sidebarRef = useRef<HTMLDivElement>(null);
@@ -369,6 +373,8 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
                     focusedItemId={focusedItemId}
                     indentPerLevel={props.documentTreeIndent}
                     verticalSpacing={props.documentTreeVerticalSpacing}
+                    openDocumentIds={openDocumentIdSet}
+                    activeDocumentId={props.activeDocumentId}
                     onSelectNode={props.onSelectNode}
                     onDeleteNode={props.onDeleteNode}
                     onRenameNode={props.onRenameNode}


### PR DESCRIPTION
## Summary
- pass open document tab context from the app sidebar into the document tree items
- render a tab status indicator beside document nodes and accent the active document tab in the tree

## Testing
- npm run build *(fails: tailwindcss CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e8e2d3b88332aecc604ecab04c28