### PR TITLE
feat: add multi-workspace SQLite support

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -157,6 +157,15 @@ ipcMain.handle('db:migrate-from-json', (_, data) => databaseService.migrateFromJ
 ipcMain.handle('db:duplicate-nodes', (_, nodeIds) => databaseService.duplicateNodes(nodeIds));
 ipcMain.handle('db:delete-versions', (_, documentId, versionIds) => databaseService.deleteVersions(documentId, versionIds));
 ipcMain.handle('db:get-path', () => databaseService.getDbPath());
+ipcMain.handle('db:list-workspaces', () => databaseService.listWorkspaces());
+ipcMain.handle('db:create-workspace', (_, name: string) => databaseService.createWorkspace(name));
+ipcMain.handle('db:rename-workspace', (_, workspaceId: string, newName: string) => databaseService.renameWorkspace(workspaceId, newName));
+ipcMain.handle('db:delete-workspace', (_, workspaceId: string) => databaseService.deleteWorkspace(workspaceId));
+ipcMain.handle('db:switch-workspace', (_, workspaceId: string) => databaseService.switchWorkspace(workspaceId));
+ipcMain.handle('db:get-active-workspace', () => databaseService.getActiveWorkspace());
+ipcMain.handle('db:transfer-nodes', (_, nodeIds: string[], targetWorkspaceId: string, targetParentId: string | null) =>
+  databaseService.transferNodesToWorkspace(nodeIds, targetWorkspaceId, targetParentId)
+);
 ipcMain.handle('db:import-files', async (_, filesData, targetParentId) => {
     try {
         const result = databaseService.importFiles(filesData, targetParentId);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -14,6 +14,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   dbVacuum: () => ipcRenderer.invoke('db:vacuum'),
   dbGetStats: () => ipcRenderer.invoke('db:get-stats'),
   dbGetPath: () => ipcRenderer.invoke('db:get-path'),
+  dbListWorkspaces: () => ipcRenderer.invoke('db:list-workspaces'),
+  dbCreateWorkspace: (name: string) => ipcRenderer.invoke('db:create-workspace', name),
+  dbRenameWorkspace: (workspaceId: string, newName: string) => ipcRenderer.invoke('db:rename-workspace', workspaceId, newName),
+  dbDeleteWorkspace: (workspaceId: string) => ipcRenderer.invoke('db:delete-workspace', workspaceId),
+  dbSwitchWorkspace: (workspaceId: string) => ipcRenderer.invoke('db:switch-workspace', workspaceId),
+  dbGetActiveWorkspace: () => ipcRenderer.invoke('db:get-active-workspace'),
+  dbTransferNodes: (nodeIds: string[], targetWorkspaceId: string, targetParentId: string | null) =>
+    ipcRenderer.invoke('db:transfer-nodes', nodeIds, targetWorkspaceId, targetParentId),
   dbImportFiles: (filesData: any[], targetParentId: string | null) => ipcRenderer.invoke('db:import-files', filesData, targetParentId),
 
   // --- Migration-related FS access ---

--- a/types.ts
+++ b/types.ts
@@ -17,6 +17,17 @@ declare global {
       dbVacuum: () => Promise<{ success: boolean; error?: string }>;
       dbGetStats: () => Promise<{ success: boolean; stats?: DatabaseStats; error?: string }>;
       dbGetPath: () => Promise<string>;
+      dbListWorkspaces: () => Promise<WorkspaceInfo[]>;
+      dbCreateWorkspace: (name: string) => Promise<WorkspaceInfo>;
+      dbRenameWorkspace: (workspaceId: string, newName: string) => Promise<WorkspaceInfo>;
+      dbDeleteWorkspace: (workspaceId: string) => Promise<{ success: boolean; error?: string }>;
+      dbSwitchWorkspace: (workspaceId: string) => Promise<WorkspaceInfo>;
+      dbGetActiveWorkspace: () => Promise<WorkspaceInfo | null>;
+      dbTransferNodes: (
+        nodeIds: string[],
+        targetWorkspaceId: string,
+        targetParentId: string | null,
+      ) => Promise<{ success: boolean; createdNodeIds?: string[]; error?: string }>;
       // FIX: Add missing `dbImportFiles` to the electronAPI type definition.
       dbImportFiles: (
         filesData: { path: string; name: string; content: string }[],
@@ -321,6 +332,16 @@ export interface DiscoveredLLMService {
 export interface DiscoveredLLMModel {
   id: string;
   name: string;
+}
+
+export interface WorkspaceInfo {
+  workspaceId: string;
+  name: string;
+  filePath: string;
+  createdAt: string;
+  updatedAt: string;
+  lastOpenedAt: string | null;
+  isActive: boolean;
 }
 
 export interface DatabaseStats {


### PR DESCRIPTION
## Summary
- add workspace metadata management and active workspace switching to the Electron database service, including node transfer between databases
- expose workspace management IPC endpoints to the preload bridge and repository so the renderer can list, create, switch, and delete workspaces
- introduce shared WorkspaceInfo types for renderer logic and update repository helpers to call the new transfer API

## Testing
- npm install *(fails: network ENETUNREACH while downloading vizjs)*

------
https://chatgpt.com/codex/tasks/task_e_68e538b037208332a23bc0843b0e80f1