### PR TITLE
Document document tab strip features

### DIFF
--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -39,6 +39,13 @@ The entire list of documents and templates can be navigated using your keyboard'
 
 This is the largest part of the application and displays the active content.
 
+- **Document Tab Strip:** Opened documents appear in a horizontal strip above the editor. Tabs show the document title, file
+  type badge, and an unsaved indicator so you can tell which files still need to be saved. Drag a tab to reorder it or tear it
+  away into a separate window when multi-window mode is available.
+- **Context Menu Actions:** Right-clicking a tab reveals commands to close the current document, close all other tabs, close
+  the tabs to the right, duplicate the document into a new tab, or pin the tab so it always stays visible.
+- **Overflow Picker:** When there are more tabs than can fit, the strip shows an overflow chevron. Clicking it opens a list of
+  all open documents with search-as-you-type filtering so you can quickly jump to any tab.
 - **Welcome Screen:** Shown when no document is selected.
 - **Folder Overview:** Selecting a folder opens the Folder Overview, providing a summary of its contents and quick actions.
 - **Document Editor:** The primary interface for writing and editing a document's content and title.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ DocForge is a desktop application designed to streamline the process of creating
 - **Hierarchical Document Organization:** Organize your documents in a familiar folder structure. Create nested subfolders, duplicate items, and use drag-and-drop to rearrange your workspace or import files from your computer.
 - **Full Context Menu & Keyboard Navigation:** Navigate and manage items using a complete right-click context menu or use only the keyboard for a faster workflow.
 - **Universal Monaco Editor:** A powerful, VS Code-like editor is used for all document types, including Markdown, HTML, and various source code files, with syntax highlighting and code folding.
+- **Multi-Document Tabs:** Keep several documents open at once, pin important files, and quickly jump between them using the tab strip and overflow picker.
 - **Multi-Format Live Preview:** Get a real-time, rendered preview for multiple document types (including Markdown and HTML). The preview can be displayed side-by-side (vertically or horizontally) with the editor.
 - **AI-Powered Refinement:** Use your connected local LLM to automatically refine and improve your documents with a single click.
 - **Document Templating:** Create reusable document templates with variables to quickly generate new documents for recurring tasks.

--- a/docs/FUNCTIONAL_MANUAL.md
+++ b/docs/FUNCTIONAL_MANUAL.md
@@ -39,6 +39,13 @@ The entire list of documents and templates can be navigated using your keyboard'
 
 This is the largest part of the application and displays the active content.
 
+- **Document Tab Strip:** Opened documents appear in a horizontal strip above the editor. Tabs show the document title, file
+  type badge, and an unsaved indicator so you can tell which files still need to be saved. Drag a tab to reorder it or tear it
+  away into a separate window when multi-window mode is available.
+- **Context Menu Actions:** Right-clicking a tab reveals commands to close the current document, close all other tabs, close
+  the tabs to the right, duplicate the document into a new tab, or pin the tab so it always stays visible.
+- **Overflow Picker:** When there are more tabs than can fit, the strip shows an overflow chevron. Clicking it opens a list of
+  all open documents with search-as-you-type filtering so you can quickly jump to any tab.
 - **Welcome Screen:** Shown when no document is selected.
 - **Folder Overview:** Selecting a folder opens the Folder Overview, providing a summary of its contents and quick actions.
 - **Document Editor:** The primary interface for writing and editing a document's content and title.


### PR DESCRIPTION
## Summary
- describe the document tab strip, context menu, and overflow picker in the main window section of the functional manual
- mirror the documentation updates in the published docs copy
- highlight multi-document tabbing in the README key features list

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e553e5a5b08332850c00dbd3b6d1e8