### PR TITLE
feat: propagate workspace context to renderer services

### DIFF
--- a/electron/database.ts
+++ b/electron/database.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron';
+import { EventEmitter } from 'events';
 import path from 'path';
 import fs, { statSync } from 'fs';
 import Database from 'better-sqlite3';
@@ -6,12 +7,63 @@ import { INITIAL_SCHEMA } from './schema';
 import { v4 as uuidv4 } from 'uuid';
 import * as crypto from 'crypto';
 // Fix: Import types to use for casting
-import type { Node, Document, DocVersion, DatabaseStats, DocType, ViewMode, ImportedNodeSummary } from '../types';
+import type {
+  Node,
+  Document,
+  DocVersion,
+  DatabaseStats,
+  DocType,
+  ViewMode,
+  ImportedNodeSummary,
+  WorkspaceInfo,
+  WorkspaceConnectionEvent,
+} from '../types';
 
-let db: Database.Database;
+type WorkspaceRecord = {
+  workspaceId: string;
+  name: string;
+  fileName: string;
+  createdAt: string;
+  updatedAt: string;
+  lastOpenedAt: string | null;
+};
 
-const DB_FILE_NAME = 'docforge.db';
-const DB_PATH = path.join(app.getPath('userData'), DB_FILE_NAME);
+type NodePythonSettingsRow = {
+  node_id: string;
+  env_id: string | null;
+  auto_detect_env: number;
+  last_run_id: string | null;
+  updated_at: string;
+};
+
+type TransferDocVersionRow = DocVersion & {
+  sha256_hex: string;
+  text_content: string | null;
+  blob_content: Buffer | null;
+};
+
+type TransferNode = {
+  node: Node;
+  document?: (Document & { versions: TransferDocVersionRow[] });
+  pythonSettings?: NodePythonSettingsRow;
+  children: TransferNode[];
+};
+
+type WorkspaceConnectionEntry = {
+  workspaceId: string;
+  connection: Database.Database;
+  openedAt: string;
+};
+
+const serviceEvents = new EventEmitter();
+const connectionRegistry = new Map<string, WorkspaceConnectionEntry>();
+
+let workspaceRecords: WorkspaceRecord[] = [];
+let activeWorkspaceId: string | null = null;
+
+const WORKSPACE_DIRECTORY = path.join(app.getPath('userData'), 'workspaces');
+const WORKSPACE_METADATA_FILE = path.join(WORKSPACE_DIRECTORY, 'workspaces.json');
+const DEFAULT_WORKSPACE_NAME = 'Main Workspace';
 
 const DOCUMENT_SEARCH_OBJECTS_SQL = `
   DROP TRIGGER IF EXISTS document_search_after_document_insert;
@@ -87,9 +139,9 @@ const DOCUMENT_SEARCH_OBJECTS_SQL = `
   END;
 `;
 
-const populateDocumentSearch = () => {
-  db.exec('DELETE FROM document_search;');
-  db.exec(`
+const populateDocumentSearch = (connection: Database.Database) => {
+  connection.exec('DELETE FROM document_search;');
+  connection.exec(`
     INSERT INTO document_search(rowid, document_id, node_id, title, body)
     SELECT
       d.document_id,
@@ -102,6 +154,290 @@ const populateDocumentSearch = () => {
     LEFT JOIN doc_versions dv ON d.current_version_id = dv.version_id
     LEFT JOIN content_store cs ON dv.content_id = cs.content_id;
   `);
+};
+
+const ensureWorkspaceDirectory = () => {
+  if (!fs.existsSync(WORKSPACE_DIRECTORY)) {
+    fs.mkdirSync(WORKSPACE_DIRECTORY, { recursive: true });
+  }
+};
+
+const getWorkspaceDbPath = (workspace: WorkspaceRecord): string =>
+  path.join(WORKSPACE_DIRECTORY, workspace.fileName);
+
+const loadWorkspaceMetadata = (): WorkspaceRecord[] => {
+  if (!fs.existsSync(WORKSPACE_METADATA_FILE)) {
+    return [];
+  }
+
+  try {
+    const raw = fs.readFileSync(WORKSPACE_METADATA_FILE, 'utf-8');
+    const parsed = JSON.parse(raw) as WorkspaceRecord[];
+    return parsed.map(record => ({
+      workspaceId: record.workspaceId,
+      name: record.name,
+      fileName: record.fileName,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+      lastOpenedAt: record.lastOpenedAt ?? null,
+    }));
+  } catch (error) {
+    console.warn('Failed to read workspace metadata, starting with empty list.', error);
+    return [];
+  }
+};
+
+const persistWorkspaceMetadata = () => {
+  ensureWorkspaceDirectory();
+  try {
+    fs.writeFileSync(
+      WORKSPACE_METADATA_FILE,
+      JSON.stringify(workspaceRecords, null, 2),
+      'utf-8',
+    );
+  } catch (error) {
+    console.error('Failed to persist workspace metadata:', error);
+  }
+};
+
+const toWorkspaceInfo = (record: WorkspaceRecord): WorkspaceInfo => ({
+  workspaceId: record.workspaceId,
+  name: record.name,
+  filePath: getWorkspaceDbPath(record),
+  createdAt: record.createdAt,
+  updatedAt: record.updatedAt,
+  lastOpenedAt: record.lastOpenedAt,
+  isActive: activeWorkspaceId === record.workspaceId,
+  isOpen: connectionRegistry.has(record.workspaceId),
+});
+
+const selectWorkspaceToOpen = (): WorkspaceRecord | null => {
+  if (workspaceRecords.length === 0) {
+    return null;
+  }
+
+  const sorted = [...workspaceRecords].sort((a, b) => {
+    if (a.lastOpenedAt && b.lastOpenedAt) {
+      return a.lastOpenedAt > b.lastOpenedAt ? -1 : 1;
+    }
+    if (a.lastOpenedAt) return -1;
+    if (b.lastOpenedAt) return 1;
+    return a.createdAt > b.createdAt ? -1 : 1;
+  });
+
+  return sorted[0];
+};
+
+const getWorkspaceRecordOrThrow = (workspaceId: string): WorkspaceRecord => {
+  const record = workspaceRecords.find(item => item.workspaceId === workspaceId);
+  if (!record) {
+    throw new Error(`Workspace with id ${workspaceId} was not found.`);
+  }
+  return record;
+};
+
+const emitWorkspaceEvent = (event: WorkspaceConnectionEvent['type'], record: WorkspaceRecord) => {
+  const info = toWorkspaceInfo(record);
+  serviceEvents.emit(event, info);
+  serviceEvents.emit('workspace-event', { type: event, workspace: info });
+};
+
+const registerWorkspaceConnection = (workspace: WorkspaceRecord): Database.Database => {
+  const existing = connectionRegistry.get(workspace.workspaceId);
+  if (existing) {
+    return existing.connection;
+  }
+
+  const connection = openWorkspaceConnection(workspace);
+  connectionRegistry.set(workspace.workspaceId, {
+    workspaceId: workspace.workspaceId,
+    connection,
+    openedAt: new Date().toISOString(),
+  });
+
+  emitWorkspaceEvent('workspace-opened', workspace);
+  return connection;
+};
+
+const disposeWorkspaceConnection = (workspaceId: string) => {
+  const entry = connectionRegistry.get(workspaceId);
+  if (!entry) {
+    return;
+  }
+
+  const workspace = getWorkspaceRecordOrThrow(workspaceId);
+
+  try {
+    entry.connection.close();
+  } catch (error) {
+    console.warn('Failed to close workspace connection:', error);
+  }
+
+  connectionRegistry.delete(workspaceId);
+  emitWorkspaceEvent('workspace-closed', workspace);
+};
+
+const resolveConnection = (workspaceId?: string): { connection: Database.Database; workspace: WorkspaceRecord } => {
+  const id = workspaceId ?? activeWorkspaceId;
+  if (!id) {
+    throw new Error('No active workspace is selected.');
+  }
+
+  const workspace = getWorkspaceRecordOrThrow(id);
+  const existing = connectionRegistry.get(id);
+  if (existing) {
+    return { connection: existing.connection, workspace };
+  }
+
+  const connection = registerWorkspaceConnection(workspace);
+  return { connection, workspace };
+};
+
+const reopenWorkspaceConnection = (workspaceId: string): Database.Database => {
+  const workspace = getWorkspaceRecordOrThrow(workspaceId);
+  disposeWorkspaceConnection(workspaceId);
+  return registerWorkspaceConnection(workspace);
+};
+
+const closeAllConnections = () => {
+  for (const workspaceId of Array.from(connectionRegistry.keys())) {
+    disposeWorkspaceConnection(workspaceId);
+  }
+};
+
+const withConnection = <T>(
+  workspaceId: string | undefined,
+  callback: (connection: Database.Database, workspace: WorkspaceRecord) => T,
+): T => {
+  const { connection, workspace } = resolveConnection(workspaceId);
+  return callback(connection, workspace);
+};
+
+const prepareDatabaseConnection = (connection: Database.Database, isNew: boolean) => {
+  if (isNew) {
+    console.log('Database does not exist, creating new one...');
+    connection.exec(INITIAL_SCHEMA);
+    connection.pragma('user_version = 3');
+    connection.exec('PRAGMA journal_mode = WAL;');
+    connection.exec('PRAGMA foreign_keys = ON;');
+    console.log('Database created and schema applied.');
+    return;
+  }
+
+  console.log('Existing database found.');
+  connection.exec('PRAGMA journal_mode = WAL;');
+  connection.exec('PRAGMA foreign_keys = ON;');
+
+  let currentVersion = connection.pragma('user_version', { simple: true }) as number;
+  if (currentVersion < 1) {
+    console.log(`Migrating schema from version ${currentVersion} to 1...`);
+    try {
+      const transaction = connection.transaction(() => {
+        const columns = connection.prepare("PRAGMA table_info(documents)").all() as {name: string}[];
+        const hasColumn = columns.some(col => col.name === 'default_view_mode');
+        if (!hasColumn) {
+          connection.exec('ALTER TABLE documents ADD COLUMN default_view_mode TEXT');
+        }
+        connection.pragma('user_version = 1');
+      });
+      transaction();
+      currentVersion = 1;
+      console.log('Migration to version 1 complete.');
+    } catch (e) {
+      console.error('Fatal: Failed to migrate database to version 1:', e);
+    }
+  }
+
+  if (currentVersion < 2) {
+    console.log(`Migrating schema from version ${currentVersion} to 2...`);
+    try {
+      const transaction = connection.transaction(() => {
+        connection.exec(`
+          CREATE TABLE IF NOT EXISTS python_environments (
+            env_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            python_executable TEXT NOT NULL,
+            python_version TEXT NOT NULL,
+            managed INTEGER NOT NULL DEFAULT 1,
+            config_json TEXT NOT NULL,
+            working_directory TEXT,
+            description TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );
+        `);
+
+        connection.exec(`
+          CREATE TABLE IF NOT EXISTS python_execution_runs (
+            run_id TEXT PRIMARY KEY,
+            node_id TEXT NOT NULL REFERENCES nodes(node_id) ON DELETE CASCADE,
+            env_id TEXT REFERENCES python_environments(env_id) ON DELETE SET NULL,
+            status TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            finished_at TEXT,
+            exit_code INTEGER,
+            error_message TEXT,
+            duration_ms INTEGER
+          );
+        `);
+
+        connection.exec(`
+          CREATE TABLE IF NOT EXISTS python_execution_logs (
+            log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL REFERENCES python_execution_runs(run_id) ON DELETE CASCADE,
+            timestamp TEXT NOT NULL,
+            level TEXT NOT NULL,
+            message TEXT NOT NULL
+          );
+        `);
+
+        connection.exec(`
+          CREATE TABLE IF NOT EXISTS node_python_settings (
+            node_id TEXT PRIMARY KEY REFERENCES nodes(node_id) ON DELETE CASCADE,
+            env_id TEXT REFERENCES python_environments(env_id) ON DELETE SET NULL,
+            auto_detect_env INTEGER NOT NULL DEFAULT 1,
+            last_run_id TEXT REFERENCES python_execution_runs(run_id) ON DELETE SET NULL,
+            updated_at TEXT NOT NULL
+          );
+        `);
+
+        connection.exec('CREATE INDEX IF NOT EXISTS idx_python_runs_node ON python_execution_runs(node_id);');
+        connection.exec('CREATE INDEX IF NOT EXISTS idx_python_runs_env ON python_execution_runs(env_id);');
+        connection.exec('CREATE INDEX IF NOT EXISTS idx_python_logs_run ON python_execution_logs(run_id);');
+
+        connection.pragma('user_version = 2');
+      });
+      transaction();
+      currentVersion = 2;
+      console.log('Migration to version 2 complete.');
+    } catch (e) {
+      console.error('Fatal: Failed to migrate database to version 2:', e);
+    }
+  }
+
+  if (currentVersion < 3) {
+    console.log(`Migrating schema from version ${currentVersion} to 3...`);
+    try {
+      const transaction = connection.transaction(() => {
+        connection.exec(DOCUMENT_SEARCH_OBJECTS_SQL);
+        populateDocumentSearch(connection);
+        connection.pragma('user_version = 3');
+      });
+      transaction();
+      console.log('Migration to version 3 complete.');
+    } catch (e) {
+      console.error('Fatal: Failed to migrate database to version 3:', e);
+    }
+  }
+};
+
+const openWorkspaceConnection = (workspace: WorkspaceRecord): Database.Database => {
+  ensureWorkspaceDirectory();
+  const dbPath = getWorkspaceDbPath(workspace);
+  const dbExists = fs.existsSync(dbPath);
+  const connection = new Database(dbPath);
+  prepareDatabaseConnection(connection, !dbExists);
+  return connection;
 };
 
 // Helper function from languageService.ts, now inside database.ts to avoid cross-context dependencies
@@ -157,520 +493,707 @@ const mapExtensionToLanguageId_local = (extension: string | null): string => {
 
 export const databaseService = {
   init() {
-    const dbExists = fs.existsSync(DB_PATH);
-    db = new Database(DB_PATH);
+    ensureWorkspaceDirectory();
+    closeAllConnections();
+    workspaceRecords = loadWorkspaceMetadata();
+    activeWorkspaceId = null;
 
-    if (!dbExists) {
-      console.log('Database does not exist, creating new one...');
-      db.exec(INITIAL_SCHEMA);
-      // Set PRAGMAs for a new database
-      db.pragma('user_version = 3');
-      db.exec('PRAGMA journal_mode = WAL;');
-      db.exec('PRAGMA foreign_keys = ON;');
-      console.log('Database created and schema applied.');
-    } else {
-      console.log('Existing database found.');
-      // Ensure PRAGMAs are set for existing databases too
-      db.exec('PRAGMA journal_mode = WAL;');
-      db.exec('PRAGMA foreign_keys = ON;');
-      
-      // Run migrations
-      const currentVersion = db.pragma('user_version', { simple: true }) as number;
-      if (currentVersion < 1) {
-        console.log(`Migrating schema from version ${currentVersion} to 1...`);
-        try {
-          const transaction = db.transaction(() => {
-            const columns = db.prepare("PRAGMA table_info(documents)").all() as {name: string}[];
-            const hasColumn = columns.some(col => col.name === 'default_view_mode');
-            if (!hasColumn) {
-              db.exec('ALTER TABLE documents ADD COLUMN default_view_mode TEXT');
-            }
-            db.pragma('user_version = 1');
-          });
-          transaction();
-          console.log('Migration to version 1 complete.');
-        } catch (e) {
-          console.error('Fatal: Failed to migrate database to version 1:', e);
-        }
-      }
+    if (workspaceRecords.length === 0) {
+      const now = new Date().toISOString();
+      const workspaceId = uuidv4();
+      const defaultRecord: WorkspaceRecord = {
+        workspaceId,
+        name: DEFAULT_WORKSPACE_NAME,
+        fileName: `${workspaceId}.db`,
+        createdAt: now,
+        updatedAt: now,
+        lastOpenedAt: now,
+      };
 
-      if (currentVersion < 2) {
-        console.log(`Migrating schema from version ${currentVersion} to 2...`);
-        try {
-          const transaction = db.transaction(() => {
-            db.exec(`
-              CREATE TABLE IF NOT EXISTS python_environments (
-                env_id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                python_executable TEXT NOT NULL,
-                python_version TEXT NOT NULL,
-                managed INTEGER NOT NULL DEFAULT 1,
-                config_json TEXT NOT NULL,
-                working_directory TEXT,
-                description TEXT,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-              );
-            `);
+      const connection = openWorkspaceConnection(defaultRecord);
+      connection.close();
 
-            db.exec(`
-              CREATE TABLE IF NOT EXISTS python_execution_runs (
-                run_id TEXT PRIMARY KEY,
-                node_id TEXT NOT NULL REFERENCES nodes(node_id) ON DELETE CASCADE,
-                env_id TEXT REFERENCES python_environments(env_id) ON DELETE SET NULL,
-                status TEXT NOT NULL,
-                started_at TEXT NOT NULL,
-                finished_at TEXT,
-                exit_code INTEGER,
-                error_message TEXT,
-                duration_ms INTEGER
-              );
-            `);
-
-            db.exec(`
-              CREATE TABLE IF NOT EXISTS python_execution_logs (
-                log_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                run_id TEXT NOT NULL REFERENCES python_execution_runs(run_id) ON DELETE CASCADE,
-                timestamp TEXT NOT NULL,
-                level TEXT NOT NULL,
-                message TEXT NOT NULL
-              );
-            `);
-
-            db.exec(`
-              CREATE TABLE IF NOT EXISTS node_python_settings (
-                node_id TEXT PRIMARY KEY REFERENCES nodes(node_id) ON DELETE CASCADE,
-                env_id TEXT REFERENCES python_environments(env_id) ON DELETE SET NULL,
-                auto_detect_env INTEGER NOT NULL DEFAULT 1,
-                last_run_id TEXT REFERENCES python_execution_runs(run_id) ON DELETE SET NULL,
-                updated_at TEXT NOT NULL
-              );
-            `);
-
-            db.exec('CREATE INDEX IF NOT EXISTS idx_python_runs_node ON python_execution_runs(node_id);');
-            db.exec('CREATE INDEX IF NOT EXISTS idx_python_runs_env ON python_execution_runs(env_id);');
-            db.exec('CREATE INDEX IF NOT EXISTS idx_python_logs_run ON python_execution_logs(run_id);');
-
-            db.pragma('user_version = 2');
-          });
-          transaction();
-          console.log('Migration to version 2 complete.');
-        } catch (e) {
-          console.error('Fatal: Failed to migrate database to version 2:', e);
-        }
-      }
-
-      if (currentVersion < 3) {
-        console.log(`Migrating schema from version ${currentVersion} to 3...`);
-        try {
-          const transaction = db.transaction(() => {
-            db.exec(DOCUMENT_SEARCH_OBJECTS_SQL);
-            populateDocumentSearch();
-            db.pragma('user_version = 3');
-          });
-          transaction();
-          console.log('Migration to version 3 complete.');
-        } catch (e) {
-          console.error('Fatal: Failed to migrate database to version 3:', e);
-        }
-      }
+      workspaceRecords.push(defaultRecord);
+      persistWorkspaceMetadata();
     }
+
+    const workspaceToOpen = selectWorkspaceToOpen() ?? workspaceRecords[0];
+    this.switchWorkspace(workspaceToOpen.workspaceId);
   },
 
-  isNew(): boolean {
-    const tableCheck = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='nodes'").get();
+  switchWorkspace(workspaceId: string): WorkspaceInfo {
+    const target = getWorkspaceRecordOrThrow(workspaceId);
+    registerWorkspaceConnection(target);
+
+    const now = new Date().toISOString();
+    target.lastOpenedAt = now;
+    target.updatedAt = now;
+    persistWorkspaceMetadata();
+
+    const previousActive = activeWorkspaceId;
+    activeWorkspaceId = target.workspaceId;
+
+    if (previousActive !== target.workspaceId) {
+      emitWorkspaceEvent('workspace-activated', target);
+    } else {
+      // Emit activation event even when re-selecting the same workspace to allow refresh flows.
+      emitWorkspaceEvent('workspace-activated', target);
+    }
+
+    return toWorkspaceInfo(target);
+  },
+
+  openWorkspaceConnection(workspaceId: string): WorkspaceInfo {
+    const target = getWorkspaceRecordOrThrow(workspaceId);
+    registerWorkspaceConnection(target);
+    return toWorkspaceInfo(target);
+  },
+
+  closeWorkspaceConnection(workspaceId: string): WorkspaceInfo {
+    const target = getWorkspaceRecordOrThrow(workspaceId);
+    disposeWorkspaceConnection(workspaceId);
+    return toWorkspaceInfo(target);
+  },
+
+  refreshWorkspaceConnection(workspaceId: string): WorkspaceInfo {
+    const target = getWorkspaceRecordOrThrow(workspaceId);
+    reopenWorkspaceConnection(workspaceId);
+    return toWorkspaceInfo(target);
+  },
+
+  listWorkspaces(): WorkspaceInfo[] {
+    return workspaceRecords.map(toWorkspaceInfo);
+  },
+
+  createWorkspace(name: string): WorkspaceInfo {
+    const trimmedName = name?.trim();
+    const resolvedName = trimmedName && trimmedName.length > 0
+      ? trimmedName
+      : `Workspace ${workspaceRecords.length + 1}`;
+
+    const now = new Date().toISOString();
+    const workspaceId = uuidv4();
+    const record: WorkspaceRecord = {
+      workspaceId,
+      name: resolvedName,
+      fileName: `${workspaceId}.db`,
+      createdAt: now,
+      updatedAt: now,
+      lastOpenedAt: null,
+    };
+
+    const connection = openWorkspaceConnection(record);
+    connection.close();
+
+    workspaceRecords.push(record);
+    persistWorkspaceMetadata();
+
+    return toWorkspaceInfo(record);
+  },
+
+  renameWorkspace(workspaceId: string, newName: string): WorkspaceInfo {
+    const record = workspaceRecords.find(item => item.workspaceId === workspaceId);
+    if (!record) {
+      throw new Error(`Workspace with id ${workspaceId} was not found.`);
+    }
+
+    const trimmed = newName?.trim();
+    if (!trimmed) {
+      throw new Error('Workspace name cannot be empty.');
+    }
+
+    record.name = trimmed;
+    record.updatedAt = new Date().toISOString();
+    persistWorkspaceMetadata();
+
+    return toWorkspaceInfo(record);
+  },
+
+  deleteWorkspace(workspaceId: string): { success: boolean; error?: string } {
+    const recordIndex = workspaceRecords.findIndex(item => item.workspaceId === workspaceId);
+    if (recordIndex === -1) {
+      return { success: false, error: `Workspace with id ${workspaceId} was not found.` };
+    }
+
+    if (activeWorkspaceId === workspaceId) {
+      return { success: false, error: 'Cannot delete the active workspace.' };
+    }
+
+    disposeWorkspaceConnection(workspaceId);
+    const [record] = workspaceRecords.splice(recordIndex, 1);
+    persistWorkspaceMetadata();
+
+    try {
+      const dbPath = getWorkspaceDbPath(record);
+      if (fs.existsSync(dbPath)) {
+        fs.unlinkSync(dbPath);
+      }
+    } catch (error) {
+      console.warn('Failed to remove workspace database file:', error);
+    }
+
+    return { success: true };
+  },
+
+  getActiveWorkspace(): WorkspaceInfo | null {
+    return activeWorkspaceId ? toWorkspaceInfo(getWorkspaceRecordOrThrow(activeWorkspaceId)) : null;
+  },
+
+  isNew(workspaceId?: string): boolean {
+    const { connection } = resolveConnection(workspaceId);
+    const tableCheck = connection.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='nodes'").get();
     return !tableCheck;
   },
-  
-  query(sql: string, params: any[] = []): any[] {
+
+  query(sql: string, params: any[] = [], workspaceId?: string): any[] {
+    const { connection } = resolveConnection(workspaceId);
     try {
-      return db.prepare(sql).all(...(params || []));
+      return connection.prepare(sql).all(...(params || []));
     } catch(e) {
       console.error("DB Query Error:", sql, params, e);
       throw e;
     }
   },
 
-  get(sql: string, params: any[] = []): any {
+  get(sql: string, params: any[] = [], workspaceId?: string): any {
+    const { connection } = resolveConnection(workspaceId);
     try {
-      return db.prepare(sql).get(...(params || []));
+      return connection.prepare(sql).get(...(params || []));
     } catch(e) {
       console.error("DB Get Error:", sql, params, e);
       throw e;
     }
   },
-  
-  run(sql: string, params: any[] = []): Database.RunResult {
+
+  run(sql: string, params: any[] = [], workspaceId?: string): Database.RunResult {
+    const { connection } = resolveConnection(workspaceId);
     try {
-      return db.prepare(sql).run(...(params || []));
+      return connection.prepare(sql).run(...(params || []));
     } catch(e) {
       console.error("DB Run Error:", sql, params, e);
       throw e;
     }
   },
 
-  migrateFromJson(data: any): { success: boolean, error?: string } {
-    const transaction = db.transaction(() => {
+  migrateFromJson(data: any, workspaceId?: string): { success: boolean, error?: string } {
+    return withConnection(workspaceId, (connection) => {
+      const transaction = connection.transaction(() => {
         // Clear existing data for a clean migration slate.
-        db.exec('DELETE FROM settings;');
-        db.exec('DELETE FROM templates;');
-        db.exec('DELETE FROM doc_versions;');
-        db.exec('DELETE FROM content_store;');
-        db.exec('DELETE FROM documents;');
-        db.exec('DELETE FROM nodes;');
+        connection.exec('DELETE FROM settings;');
+        connection.exec('DELETE FROM templates;');
+        connection.exec('DELETE FROM doc_versions;');
+        connection.exec('DELETE FROM content_store;');
+        connection.exec('DELETE FROM documents;');
+        connection.exec('DELETE FROM nodes;');
 
         // Insert Content
-        const contentStmt = db.prepare('INSERT INTO content_store (sha256_hex, text_content) VALUES (?, ?)');
+        const contentStmt = connection.prepare('INSERT INTO content_store (sha256_hex, text_content) VALUES (?, ?)');
         const contentMap = new Map<string, number>();
         for (const item of data.contentStore) {
-            const result = contentStmt.run(item.sha256_hex, item.text_content);
-            contentMap.set(item.sha256_hex, Number(result.lastInsertRowid));
+          const result = contentStmt.run(item.sha256_hex, item.text_content);
+          contentMap.set(item.sha256_hex, Number(result.lastInsertRowid));
         }
 
         // Insert Nodes
-        const nodeStmt = db.prepare('INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)');
+        const nodeStmt = connection.prepare('INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)');
         for (const node of data.nodes) {
-            nodeStmt.run(node.node_id, node.parent_id, node.node_type, node.title, node.sort_order, node.created_at, node.updated_at);
+          nodeStmt.run(node.node_id, node.parent_id, node.node_type, node.title, node.sort_order, node.created_at, node.updated_at);
         }
 
         // Insert Documents and Versions
-        const docStmt = db.prepare('INSERT INTO documents (node_id, doc_type, language_hint, default_view_mode) VALUES (?, ?, ?, ?)');
-        const versionStmt = db.prepare('INSERT INTO doc_versions (document_id, created_at, content_id) VALUES (?, ?, ?)');
-        const updateDocStmt = db.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?');
+        const docStmt = connection.prepare('INSERT INTO documents (node_id, doc_type, language_hint, default_view_mode) VALUES (?, ?, ?, ?)');
+        const versionStmt = connection.prepare('INSERT INTO doc_versions (document_id, created_at, content_id) VALUES (?, ?, ?)');
+        const updateDocStmt = connection.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?');
 
         const docVersionsByNode = new Map<string, any[]>();
-        for(const version of data.docVersions) {
-            if(!docVersionsByNode.has(version.node_id)) docVersionsByNode.set(version.node_id, []);
-            docVersionsByNode.get(version.node_id)!.push(version);
+        for (const version of data.docVersions) {
+          if (!docVersionsByNode.has(version.node_id)) docVersionsByNode.set(version.node_id, []);
+          docVersionsByNode.get(version.node_id)!.push(version);
         }
 
         for (const doc of data.documents) {
-            const docResult = docStmt.run(doc.node_id, doc.doc_type, doc.language_hint, doc.default_view_mode ?? null);
-            const docId = Number(docResult.lastInsertRowid);
-            
-            const versions = docVersionsByNode.get(doc.node_id) || [];
-            // Sort versions by date to find the latest one
-            versions.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-            
-            let latestVersionId: number | null = null;
+          const docResult = docStmt.run(doc.node_id, doc.doc_type, doc.language_hint, doc.default_view_mode ?? null);
+          const docId = Number(docResult.lastInsertRowid);
 
-            for (const version of versions) {
-                const contentId = contentMap.get(version.sha256_hex);
-                if (contentId) {
-                    const versionResult = versionStmt.run(docId, version.created_at, contentId);
-                    if (!latestVersionId) {
-                        latestVersionId = Number(versionResult.lastInsertRowid);
-                    }
-                }
-            }
+          const versions = docVersionsByNode.get(doc.node_id) || [];
+          // Sort versions by date to find the latest one
+          versions.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
 
-            if (latestVersionId) {
-                updateDocStmt.run(latestVersionId, docId);
+          let latestVersionId: number | null = null;
+
+          for (const version of versions) {
+            const contentId = contentMap.get(version.sha256_hex);
+            if (contentId) {
+              const versionResult = versionStmt.run(docId, version.created_at, contentId);
+              if (!latestVersionId) {
+                latestVersionId = Number(versionResult.lastInsertRowid);
+              }
             }
+          }
+
+          if (latestVersionId) {
+            updateDocStmt.run(latestVersionId, docId);
+          }
         }
-        
+
         // Insert Templates
-        const templateStmt = db.prepare('INSERT INTO templates (template_id, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)');
+        const templateStmt = connection.prepare('INSERT INTO templates (template_id, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)');
         for (const template of data.templates) {
-            templateStmt.run(template.template_id, template.title, template.content, template.created_at, template.updated_at);
+          templateStmt.run(template.template_id, template.title, template.content, template.created_at, template.updated_at);
         }
 
         // Insert Settings
-        const settingsStmt = db.prepare('INSERT INTO settings (key, value) VALUES (?, ?)');
+        const settingsStmt = connection.prepare('INSERT INTO settings (key, value) VALUES (?, ?)');
         for (const setting of data.settings) {
-             // The `transformLegacyData` in renderer has a bug where it uses String(value)
-            // instead of JSON.stringify(value). This is problematic for empty strings,
-            // which are not valid JSON. We store it as a stringified empty string
-            // to be compatible with `JSON.parse` on the renderer side.
-            const valueToStore = setting.value === '' ? '""' : JSON.stringify(setting.value);
-            // Re-parsing what is essentially a stringified primitive to store a valid JSON string.
-            try {
-                const parsed = JSON.parse(setting.value);
-                settingsStmt.run(setting.key, JSON.stringify(parsed));
-            } catch {
-                 settingsStmt.run(setting.key, JSON.stringify(setting.value));
-            }
-        }
-
-        populateDocumentSearch();
-    });
-
-    try {
-      transaction();
-      return { success: true };
-    } catch (error) {
-      console.error('Migration transaction failed:', error);
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
-    }
-  },
-  
-  duplicateNodes(nodeIds: string[]): { success: boolean, error?: string } {
-    const transaction = db.transaction((ids: string[]) => {
-      const _recursiveDuplicate = (nodeId: string, newParentId: string | null, sortOrder: number): string => {
-        // Fix: Cast the result to the Node type to resolve property access errors.
-        const originalNode = db.prepare('SELECT * FROM nodes WHERE node_id = ?').get(nodeId) as Node;
-        if (!originalNode) return '';
-  
-        const newNodeId = uuidv4();
-        const now = new Date().toISOString();
-  
-        db.prepare(`
-          INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `).run(newNodeId, newParentId, originalNode.node_type, `Copy of ${originalNode.title}`, sortOrder, now, now);
-  
-        if (originalNode.node_type === 'document') {
-          // Fix: Cast the result to the Document type.
-          const originalDoc = db.prepare('SELECT * FROM documents WHERE node_id = ?').get(nodeId) as Document;
-          if (originalDoc) {
-            const newDocResult = db.prepare(`
-              INSERT INTO documents (node_id, doc_type, language_hint, default_view_mode, current_version_id)
-              VALUES (?, ?, ?, ?, NULL)
-            `).run(newNodeId, originalDoc.doc_type, originalDoc.language_hint, originalDoc.default_view_mode);
-            const newDocId = newDocResult.lastInsertRowid;
-  
-            // Fix: Cast the result to DocVersion array.
-            const originalVersions = db.prepare('SELECT * FROM doc_versions WHERE document_id = ?').all(originalDoc.document_id) as DocVersion[];
-            const versionMap = new Map<number, number>();
-  
-            for (const version of originalVersions) {
-              const newVersionResult = db.prepare(`
-                INSERT INTO doc_versions (document_id, created_at, content_id)
-                VALUES (?, ?, ?)
-              `).run(newDocId, version.created_at, version.content_id);
-              versionMap.set(version.version_id, Number(newVersionResult.lastInsertRowid));
-            }
-  
-            if (originalDoc.current_version_id && versionMap.has(originalDoc.current_version_id)) {
-              const newCurrentVersionId = versionMap.get(originalDoc.current_version_id)!;
-              db.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?').run(newCurrentVersionId, newDocId);
-            }
+          // The `transformLegacyData` in renderer has a bug where it uses String(value)
+          // instead of JSON.stringify(value). This is problematic for empty strings,
+          // which are not valid JSON. We store it as a stringified empty string
+          // to be compatible with `JSON.parse` on the renderer side.
+          const valueToStore = setting.value === '' ? '""' : JSON.stringify(setting.value);
+          // Re-parsing what is essentially a stringified primitive to store a valid JSON string.
+          try {
+            const parsed = JSON.parse(setting.value);
+            settingsStmt.run(setting.key, JSON.stringify(parsed));
+          } catch {
+            settingsStmt.run(setting.key, JSON.stringify(setting.value));
           }
-        } else if (originalNode.node_type === 'folder') {
-          // Fix: Cast the result to Node array.
-          const children = db.prepare('SELECT * FROM nodes WHERE parent_id = ? ORDER BY sort_order').all(nodeId) as Node[];
-          children.forEach((child, index) => {
-            _recursiveDuplicate(child.node_id, newNodeId, index);
-          });
         }
-        return newNodeId;
-      };
-  
-      const parentGroups = new Map<string, { id: string, sort_order: number }[]>();
-      for (const id of ids) {
-        // Fix: Cast the result to a specific object type.
-        const node = db.prepare('SELECT parent_id, sort_order FROM nodes WHERE node_id = ?').get(id) as { parent_id: string | null; sort_order: number; };
-        if (node) {
-          const parentIdKey = node.parent_id || 'root';
-          if (!parentGroups.has(parentIdKey)) parentGroups.set(parentIdKey, []);
-          parentGroups.get(parentIdKey)!.push({ id, sort_order: node.sort_order });
-        }
-      }
-  
-      for (const [parentIdKey, nodesToDuplicate] of parentGroups.entries()) {
-        const parentId = parentIdKey === 'root' ? null : parentIdKey;
-        // Fix: Cast the result to a specific object type.
-        const maxSortOrderResult = db.prepare(
-          `SELECT MAX(sort_order) as max_order FROM nodes WHERE parent_id ${parentId ? '= ?' : 'IS NULL'}`
-        ).get(parentId ? [parentId] : []) as { max_order: number | null };
-        let nextSortOrder = (maxSortOrderResult?.max_order ?? -1) + 1;
-  
-        // Sort nodes to duplicate by their original sort order to maintain relative position
-        nodesToDuplicate.sort((a, b) => a.sort_order - b.sort_order);
 
-        for (const node of nodesToDuplicate) {
-          _recursiveDuplicate(node.id, parentId, nextSortOrder);
-          nextSortOrder++;
-        }
+        populateDocumentSearch(connection);
+      });
+
+      try {
+        transaction();
+        return { success: true };
+      } catch (error) {
+        console.error('Migration transaction failed:', error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
       }
     });
-
-    try {
-      transaction(nodeIds);
-      return { success: true };
-    } catch (error) {
-      console.error('Duplicate nodes transaction failed:', error);
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
-    }
   },
 
-  deleteVersions(documentId: number, versionIds: number[]): { success: boolean, error?: string } {
-    if (versionIds.length === 0) {
-      return { success: true };
-    }
+  duplicateNodes(nodeIds: string[], workspaceId?: string): { success: boolean, error?: string } {
+    return withConnection(workspaceId, (connection) => {
+      const transaction = connection.transaction((ids: string[]) => {
+        const recursiveDuplicate = (nodeId: string, newParentId: string | null, sortOrder: number): string => {
+          const originalNode = connection.prepare('SELECT * FROM nodes WHERE node_id = ?').get(nodeId) as Node;
+          if (!originalNode) return '';
 
-    const transaction = db.transaction(() => {
-      const docInfo = db.prepare('SELECT current_version_id FROM documents WHERE document_id = ?').get(documentId) as { current_version_id: number | null };
-      if (!docInfo) {
-        throw new Error(`Document with id ${documentId} not found.`);
+          const newNodeId = uuidv4();
+          const now = new Date().toISOString();
+
+          connection.prepare(`
+            INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+          `).run(newNodeId, newParentId, originalNode.node_type, `Copy of ${originalNode.title}`, sortOrder, now, now);
+
+          if (originalNode.node_type === 'document') {
+            const originalDoc = connection.prepare('SELECT * FROM documents WHERE node_id = ?').get(nodeId) as Document;
+            if (originalDoc) {
+              const newDocResult = connection.prepare(`
+                INSERT INTO documents (node_id, doc_type, language_hint, default_view_mode, current_version_id)
+                VALUES (?, ?, ?, ?, NULL)
+              `).run(newNodeId, originalDoc.doc_type, originalDoc.language_hint, originalDoc.default_view_mode);
+              const newDocId = newDocResult.lastInsertRowid;
+
+              const originalVersions = connection.prepare('SELECT * FROM doc_versions WHERE document_id = ?').all(originalDoc.document_id) as DocVersion[];
+              const versionMap = new Map<number, number>();
+
+              for (const version of originalVersions) {
+                const newVersionResult = connection.prepare(`
+                  INSERT INTO doc_versions (document_id, created_at, content_id)
+                  VALUES (?, ?, ?)
+                `).run(newDocId, version.created_at, version.content_id);
+                versionMap.set(version.version_id, Number(newVersionResult.lastInsertRowid));
+              }
+
+              if (originalDoc.current_version_id && versionMap.has(originalDoc.current_version_id)) {
+                const newCurrentVersionId = versionMap.get(originalDoc.current_version_id)!;
+                connection.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?').run(newCurrentVersionId, newDocId);
+              }
+            }
+          } else if (originalNode.node_type === 'folder') {
+            const children = connection.prepare('SELECT * FROM nodes WHERE parent_id = ? ORDER BY sort_order').all(nodeId) as Node[];
+            children.forEach((child, index) => {
+              recursiveDuplicate(child.node_id, newNodeId, index);
+            });
+          }
+          return newNodeId;
+        };
+
+        const parentGroups = new Map<string, { id: string; sort_order: number }[]>();
+        for (const id of ids) {
+          const node = connection.prepare('SELECT parent_id, sort_order FROM nodes WHERE node_id = ?').get(id) as { parent_id: string | null; sort_order: number };
+          if (node) {
+            const parentIdKey = node.parent_id || 'root';
+            if (!parentGroups.has(parentIdKey)) parentGroups.set(parentIdKey, []);
+            parentGroups.get(parentIdKey)!.push({ id, sort_order: node.sort_order });
+          }
+        }
+
+        for (const [parentIdKey, nodesToDuplicate] of parentGroups.entries()) {
+          const parentId = parentIdKey === 'root' ? null : parentIdKey;
+          const maxSortOrderResult = connection.prepare(
+            `SELECT MAX(sort_order) as max_order FROM nodes WHERE parent_id ${parentId ? '= ?' : 'IS NULL'}`
+          ).get(parentId ? [parentId] : []) as { max_order: number | null };
+          let nextSortOrder = (maxSortOrderResult?.max_order ?? -1) + 1;
+
+          nodesToDuplicate.sort((a, b) => a.sort_order - b.sort_order);
+
+          for (const node of nodesToDuplicate) {
+            recursiveDuplicate(node.id, parentId, nextSortOrder);
+            nextSortOrder++;
+          }
+        }
+      });
+
+      try {
+        transaction(nodeIds);
+        return { success: true };
+      } catch (error) {
+        console.error('Duplicate nodes transaction failed:', error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
       }
-      
-      const currentVersionId = docInfo.current_version_id;
-      const idsToDelete = new Set(versionIds);
-
-      if (currentVersionId && idsToDelete.has(currentVersionId)) {
-        const placeholders = versionIds.map(() => '?').join(',');
-        const nextVersion = db.prepare(`
-          SELECT version_id FROM doc_versions 
-          WHERE document_id = ? AND version_id NOT IN (${placeholders})
-          ORDER BY created_at DESC 
-          LIMIT 1
-        `).get(documentId, ...versionIds) as { version_id: number } | undefined;
-
-        const newCurrentVersionId = nextVersion ? nextVersion.version_id : null;
-        db.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?').run(newCurrentVersionId, documentId);
-      }
-
-      const deletePlaceholders = versionIds.map(() => '?').join(',');
-      db.prepare(`DELETE FROM doc_versions WHERE version_id IN (${deletePlaceholders})`).run(...versionIds);
     });
-
-    try {
-      transaction();
-      return { success: true };
-    } catch (error) {
-      console.error('Delete versions transaction failed:', error);
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
-    }
   },
 
-  importFiles(filesData: {path: string; name: string; content: string}[], targetParentId: string | null): { success: boolean; error?: string; createdNodes: ImportedNodeSummary[] } {
-    const createdNodes: ImportedNodeSummary[] = [];
-    const transaction = db.transaction(() => {
+  deleteVersions(documentId: number, versionIds: number[], workspaceId?: string): { success: boolean, error?: string } {
+    return withConnection(workspaceId, (connection) => {
+      if (versionIds.length === 0) {
+        return { success: true };
+      }
+
+      const transaction = connection.transaction(() => {
+        const docInfo = connection.prepare('SELECT current_version_id FROM documents WHERE document_id = ?').get(documentId) as { current_version_id: number | null };
+        if (!docInfo) {
+          throw new Error(`Document with id ${documentId} not found.`);
+        }
+
+        const currentVersionId = docInfo.current_version_id;
+        const idsToDelete = new Set(versionIds);
+
+        if (currentVersionId && idsToDelete.has(currentVersionId)) {
+          const placeholders = versionIds.map(() => '?').join(',');
+          const nextVersion = connection.prepare(`
+            SELECT version_id FROM doc_versions
+            WHERE document_id = ? AND version_id NOT IN (${placeholders})
+            ORDER BY created_at DESC
+            LIMIT 1
+          `).get(documentId, ...versionIds) as { version_id: number } | undefined;
+
+          const newCurrentVersionId = nextVersion ? nextVersion.version_id : null;
+          connection.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?').run(newCurrentVersionId, documentId);
+        }
+
+        const deletePlaceholders = versionIds.map(() => '?').join(',');
+        connection.prepare(`DELETE FROM doc_versions WHERE version_id IN (${deletePlaceholders})`).run(...versionIds);
+      });
+
+      try {
+        transaction();
+        return { success: true };
+      } catch (error) {
+        console.error('Delete versions transaction failed:', error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    });
+  },
+
+  importFiles(
+    filesData: { path: string; name: string; content: string }[],
+    targetParentId: string | null,
+    workspaceId?: string,
+  ): { success: boolean; error?: string; createdNodes: ImportedNodeSummary[] } {
+    return withConnection(workspaceId, (connection, workspace) => {
+      const createdNodes: ImportedNodeSummary[] = [];
+      const transaction = connection.transaction(() => {
         console.log(`Starting import transaction for ${filesData.length} files.`);
-        const knownFolderPaths = new Map<string, string>(); // 'parentId/folderName' -> 'node_id'
+        const knownFolderPaths = new Map<string, string>();
 
         const getContentId = (content: string): number => {
-            const sha = crypto.createHash('sha256').update(content).digest('hex');
-            let contentRow = db.prepare('SELECT content_id FROM content_store WHERE sha256_hex = ?').get(sha) as { content_id: number } | undefined;
-            if (contentRow) {
-                return contentRow.content_id;
-            }
-            const result = db.prepare('INSERT INTO content_store (sha256_hex, text_content) VALUES (?, ?)').run(sha, content);
-            return Number(result.lastInsertRowid);
+          const sha = crypto.createHash('sha256').update(content).digest('hex');
+          const contentRow = connection.prepare('SELECT content_id FROM content_store WHERE sha256_hex = ?').get(sha) as { content_id: number } | undefined;
+          if (contentRow) {
+            return contentRow.content_id;
+          }
+          const result = connection.prepare('INSERT INTO content_store (sha256_hex, text_content) VALUES (?, ?)').run(sha, content);
+          return Number(result.lastInsertRowid);
         };
-        
+
         for (const file of filesData) {
-            let currentParentId = targetParentId;
-            const pathParts = file.path.split(/[/\\]/).slice(0, -1);
-            
-            for (const part of pathParts) {
-                if (!part) continue; // Skip empty parts
-                const folderPathKey = `${currentParentId || 'root'}/${part}`;
+          let currentParentId = targetParentId;
+          const pathParts = file.path.split(/[\/\\]/).slice(0, -1);
 
-                if (knownFolderPaths.has(folderPathKey)) {
-                    currentParentId = knownFolderPaths.get(folderPathKey)!;
-                } else {
-                    const existingFolder = db.prepare('SELECT node_id FROM nodes WHERE title = ? AND parent_id ' + (currentParentId ? '= ?' : 'IS NULL')).get(part, currentParentId) as { node_id: string } | undefined;
+          for (const part of pathParts) {
+            if (!part) continue;
+            const folderPathKey = `${currentParentId || 'root'}/${part}`;
 
-                    if (existingFolder) {
-                        currentParentId = existingFolder.node_id;
-                    } else {
-                        const newFolderId = uuidv4();
-                        const now = new Date().toISOString();
-                        const maxSortOrderResult = db.prepare(`SELECT MAX(sort_order) as max_order FROM nodes WHERE parent_id ${currentParentId ? '= ?' : 'IS NULL'}`).get(currentParentId) as { max_order: number | null };
-                        const sortOrder = (maxSortOrderResult?.max_order ?? -1) + 1;
+            if (knownFolderPaths.has(folderPathKey)) {
+              currentParentId = knownFolderPaths.get(folderPathKey)!;
+            } else {
+              const existingFolder = connection.prepare('SELECT node_id FROM nodes WHERE title = ? AND parent_id ' + (currentParentId ? '= ?' : 'IS NULL')).get(part, currentParentId) as { node_id: string } | undefined;
 
-                        db.prepare(`INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at) VALUES (?, ?, 'folder', ?, ?, ?, ?)`).run(newFolderId, currentParentId, part, sortOrder, now, now);
-                        console.log(`Created folder "${part}" with id ${newFolderId}`);
-                        currentParentId = newFolderId;
-                    }
-                    knownFolderPaths.set(folderPathKey, currentParentId);
-                }
+              if (existingFolder) {
+                currentParentId = existingFolder.node_id;
+              } else {
+                const newFolderId = uuidv4();
+                const now = new Date().toISOString();
+                const maxSortOrderResult = connection.prepare(`SELECT MAX(sort_order) as max_order FROM nodes WHERE parent_id ${currentParentId ? '= ?' : 'IS NULL'}`).get(currentParentId) as { max_order: number | null };
+                const sortOrder = (maxSortOrderResult?.max_order ?? -1) + 1;
+
+                connection.prepare(`INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at) VALUES (?, ?, 'folder', ?, ?, ?, ?)`).run(newFolderId, currentParentId, part, sortOrder, now, now);
+                console.log(`Created folder "${part}" with id ${newFolderId}`);
+                currentParentId = newFolderId;
+              }
+              knownFolderPaths.set(folderPathKey, currentParentId);
             }
+          }
 
-            // Now create the document node
-            const newNodeId = uuidv4();
-            const now = new Date().toISOString();
-            const maxSortOrderResult = db.prepare(`SELECT MAX(sort_order) as max_order FROM nodes WHERE parent_id ${currentParentId ? '= ?' : 'IS NULL'}`).get(currentParentId) as { max_order: number | null };
-            const sortOrder = (maxSortOrderResult?.max_order ?? -1) + 1;
-            const extension = file.name.split('.').pop() || null;
-            let languageHint = mapExtensionToLanguageId_local(extension);
+          const newNodeId = uuidv4();
+          const now = new Date().toISOString();
+          const maxSortOrderResult = connection.prepare(`SELECT MAX(sort_order) as max_order FROM nodes WHERE parent_id ${currentParentId ? '= ?' : 'IS NULL'}`).get(currentParentId) as { max_order: number | null };
+          const sortOrder = (maxSortOrderResult?.max_order ?? -1) + 1;
+          const extension = file.name.split('.').pop() || null;
+          let languageHint = mapExtensionToLanguageId_local(extension);
 
-            const trimmedContent = file.content.trim();
-            const sample = trimmedContent.slice(0, 64).toLowerCase();
-            const isPdf = languageHint === 'pdf' || sample.startsWith('data:application/pdf');
-            const isSvgContent = sample.startsWith('<svg');
-            const isImageDataUrl = sample.startsWith('data:image/');
-            const isImage = languageHint === 'image' || isImageDataUrl || isSvgContent;
+          const trimmedContent = file.content.trim();
+          const sample = trimmedContent.slice(0, 64).toLowerCase();
+          const isPdf = languageHint === 'pdf' || sample.startsWith('data:application/pdf');
+          const isSvgContent = sample.startsWith('<svg');
+          const isImageDataUrl = sample.startsWith('data:image/');
+          const isImage = languageHint === 'image' || isImageDataUrl || isSvgContent;
 
-            if (isPdf) {
-                languageHint = 'pdf';
-            } else if (isImage) {
-                languageHint = 'image';
-            }
+          if (isPdf) {
+            languageHint = 'pdf';
+          } else if (isImage) {
+            languageHint = 'image';
+          }
 
-            const docType: DocType = isPdf ? 'pdf' : isImage ? 'image' : 'source_code';
-            const defaultViewMode: ViewMode | null = docType === 'pdf' || docType === 'image' ? 'preview' : null;
+          const docType: DocType = isPdf ? 'pdf' : isImage ? 'image' : 'source_code';
+          const defaultViewMode: ViewMode | null = docType === 'pdf' || docType === 'image' ? 'preview' : null;
 
-            db.prepare(`INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at) VALUES (?, ?, 'document', ?, ?, ?, ?)`).run(newNodeId, currentParentId, file.name, sortOrder, now, now);
+          connection.prepare(`INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at) VALUES (?, ?, 'document', ?, ?, ?, ?)`).run(newNodeId, currentParentId, file.name, sortOrder, now, now);
+          const docResult = connection.prepare(`INSERT INTO documents (node_id, doc_type, language_hint, default_view_mode) VALUES (?, ?, ?, ?)`)
+            .run(newNodeId, docType, languageHint, defaultViewMode);
+          const documentId = Number(docResult.lastInsertRowid);
 
-            const docResult = db.prepare(`INSERT INTO documents (node_id, doc_type, language_hint, default_view_mode) VALUES (?, ?, ?, ?)`)
-              .run(newNodeId, docType, languageHint, defaultViewMode);
-            const documentId = Number(docResult.lastInsertRowid);
+          const contentId = getContentId(file.content);
+          const versionResult = connection.prepare('INSERT INTO doc_versions (document_id, created_at, content_id) VALUES (?, ?, ?)').run(documentId, now, contentId);
+          const newVersionId = Number(versionResult.lastInsertRowid);
+          connection.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?').run(newVersionId, documentId);
 
-            const contentId = getContentId(file.content);
-            const versionResult = db.prepare(`INSERT INTO doc_versions (document_id, created_at, content_id) VALUES (?, ?, ?)`).run(documentId, now, contentId);
-            const newVersionId = Number(versionResult.lastInsertRowid);
-            db.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?').run(newVersionId, documentId);
-            console.log(`Created document "${file.name}" with node id ${newNodeId}`);
-
-            createdNodes.push({
-                nodeId: newNodeId,
-                parentId: currentParentId ?? null,
-                docType,
-                languageHint,
-                defaultViewMode,
-            });
+          createdNodes.push({
+            nodeId: newNodeId,
+            parentId: currentParentId ?? null,
+            docType,
+            languageHint,
+            defaultViewMode,
+            workspaceId: workspace.workspaceId,
+          });
         }
-    });
+      });
 
-    try {
+      try {
         transaction();
         return { success: true, createdNodes };
-    } catch (error) {
+      } catch (error) {
         console.error('File import transaction failed:', error);
         return { success: false, error: error instanceof Error ? error.message : String(error), createdNodes: [] };
+      }
+    });
+  },
+  transferNodesToWorkspace(
+    nodeIds: string[],
+    targetWorkspaceId: string,
+    targetParentId: string | null,
+    sourceWorkspaceId?: string,
+  ): { success: boolean; createdNodeIds?: string[]; error?: string } {
+    return withConnection(sourceWorkspaceId, (sourceConnection, sourceWorkspace) => {
+      const uniqueIds = Array.from(new Set(nodeIds));
+      if (uniqueIds.length === 0) {
+        return { success: true, createdNodeIds: [] };
+      }
+
+      const targetWorkspace = getWorkspaceRecordOrThrow(targetWorkspaceId);
+      if (targetWorkspace.workspaceId === sourceWorkspace.workspaceId) {
+        return { success: false, error: 'Target workspace must be different from the source workspace.' };
+      }
+
+      let sourceOrderRows: { node_id: string; sort_order: number }[] = [];
+      try {
+        const stmt = sourceConnection.prepare('SELECT node_id, sort_order FROM nodes WHERE node_id = ?');
+        sourceOrderRows = uniqueIds.map(id => {
+          const row = stmt.get(id) as { node_id: string; sort_order: number } | undefined;
+          if (!row) {
+            throw new Error(`Node with id ${id} was not found in workspace ${sourceWorkspace.workspaceId}.`);
+          }
+          return row;
+        });
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+
+      sourceOrderRows.sort((a, b) => a.sort_order - b.sort_order);
+
+      const collectTransferTree = (connection: Database.Database, nodeId: string): TransferNode => {
+        const transferNode: TransferNode = {
+          node: connection.prepare('SELECT * FROM nodes WHERE node_id = ?').get(nodeId) as Node,
+          children: [],
+        };
+
+        if (transferNode.node.node_type === 'document') {
+          transferNode.document = connection.prepare(`
+            SELECT d.*, dv.version_id, dv.created_at, dv.content_id, cs.sha256_hex, cs.text_content, cs.blob_content
+            FROM documents d
+            LEFT JOIN doc_versions dv ON d.document_id = dv.document_id
+            LEFT JOIN content_store cs ON dv.content_id = cs.content_id
+            WHERE d.node_id = ?
+          `).get(nodeId) as TransferNode['document'];
+        }
+
+        transferNode.pythonSettings = connection.prepare('SELECT * FROM node_python_settings WHERE node_id = ?').get(nodeId) as TransferNode['pythonSettings'];
+        const childIds = connection.prepare('SELECT node_id FROM nodes WHERE parent_id = ? ORDER BY sort_order').all(nodeId) as { node_id: string }[];
+        transferNode.children = childIds.map(child => collectTransferTree(connection, child.node_id));
+
+        return transferNode;
+      };
+
+      let transferTrees: TransferNode[] = [];
+      try {
+        transferTrees = sourceOrderRows.map(row => collectTransferTree(sourceConnection, row.node_id));
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+
+      const targetConnection = registerWorkspaceConnection(targetWorkspace);
+      const createdNodeIds: string[] = [];
+
+      try {
+        if (targetParentId) {
+          const parentExists = targetConnection.prepare('SELECT node_id FROM nodes WHERE node_id = ?').get(targetParentId) as { node_id: string } | undefined;
+          if (!parentExists) {
+            throw new Error('Target parent node does not exist in the destination workspace.');
+          }
+        }
+
+        const maxSortOrderRow = targetConnection.prepare(`SELECT MAX(sort_order) as max_order FROM nodes WHERE parent_id ${targetParentId ? '= ?' : 'IS NULL'}`).get(targetParentId ? [targetParentId] : []) as { max_order: number | null };
+        let nextSortOrder = (maxSortOrderRow?.max_order ?? -1) + 1;
+
+        const contentIdCache = new Map<string, number>();
+        const resolveContentId = (sha: string, text: string | null, blob: Buffer | null) => {
+          if (contentIdCache.has(sha)) {
+            return contentIdCache.get(sha)!;
+          }
+          const existing = targetConnection.prepare('SELECT content_id FROM content_store WHERE sha256_hex = ?').get(sha) as { content_id: number } | undefined;
+          if (existing) {
+            contentIdCache.set(sha, existing.content_id);
+            return existing.content_id;
+          }
+          const insertResult = targetConnection.prepare('INSERT INTO content_store (sha256_hex, text_content, blob_content) VALUES (?, ?, ?)').run(sha, text ?? null, blob ?? null);
+          const insertedId = Number(insertResult.lastInsertRowid);
+          contentIdCache.set(sha, insertedId);
+          return insertedId;
+        };
+
+        const insertTree = (tree: TransferNode, parentId: string | null, sortOrder: number): string => {
+          const newNodeId = uuidv4();
+          targetConnection.prepare('INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(newNodeId, parentId, tree.node.node_type, tree.node.title, sortOrder, tree.node.created_at, tree.node.updated_at);
+
+          if (tree.document) {
+            const docInsert = targetConnection.prepare('INSERT INTO documents (node_id, doc_type, language_hint, default_view_mode, current_version_id) VALUES (?, ?, ?, ?, NULL)').run(newNodeId, tree.document.doc_type, tree.document.language_hint, tree.document.default_view_mode);
+            const newDocumentId = Number(docInsert.lastInsertRowid);
+
+            let newCurrentVersionId: number | null = null;
+            for (const version of tree.document.versions) {
+              const contentId = resolveContentId(version.sha256_hex, version.text_content ?? null, version.blob_content ?? null);
+              const versionInsert = targetConnection.prepare('INSERT INTO doc_versions (document_id, created_at, content_id) VALUES (?, ?, ?)').run(newDocumentId, version.created_at, contentId);
+              const newVersionId = Number(versionInsert.lastInsertRowid);
+              if (tree.document.current_version_id === version.version_id) {
+                newCurrentVersionId = newVersionId;
+              }
+            }
+
+            if (newCurrentVersionId !== null) {
+              targetConnection.prepare('UPDATE documents SET current_version_id = ? WHERE document_id = ?').run(newCurrentVersionId, newDocumentId);
+            }
+          }
+
+          if (tree.pythonSettings) {
+            targetConnection.prepare('INSERT OR REPLACE INTO node_python_settings (node_id, env_id, auto_detect_env, last_run_id, updated_at) VALUES (?, ?, ?, ?, ?)').run(newNodeId, tree.pythonSettings.env_id, tree.pythonSettings.auto_detect_env, tree.pythonSettings.last_run_id, tree.pythonSettings.updated_at);
+          }
+
+          tree.children.forEach((child, index) => {
+            insertTree(child, newNodeId, index);
+          });
+
+          return newNodeId;
+        };
+
+        const transaction = targetConnection.transaction(() => {
+          for (const tree of transferTrees) {
+            const insertedRootId = insertTree(tree, targetParentId, nextSortOrder++);
+            createdNodeIds.push(insertedRootId);
+          }
+        });
+
+        transaction();
+        targetWorkspace.updatedAt = new Date().toISOString();
+        persistWorkspaceMetadata();
+
+        return { success: true, createdNodeIds };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    });
+  },
+};
+  getDbPath(workspaceId?: string): string {
+    const id = workspaceId ?? activeWorkspaceId;
+    if (!id) {
+      throw new Error('No active workspace is selected.');
     }
+    const workspace = getWorkspaceRecordOrThrow(id);
+    return getWorkspaceDbPath(workspace);
   },
 
-  getDbPath(): string {
-    return DB_PATH;
+  async backupDatabase(filePath: string, workspaceId?: string): Promise<void> {
+    const { connection } = resolveConnection(workspaceId);
+    await connection.backup(filePath);
   },
 
-  async backupDatabase(filePath: string): Promise<void> {
-    await db.backup(filePath);
-  },
-
-  runIntegrityCheck(): string {
-    const results = db.pragma('integrity_check');
+  runIntegrityCheck(workspaceId?: string): string {
+    const { connection } = resolveConnection(workspaceId);
+    const results = connection.pragma('integrity_check');
     if (Array.isArray(results) && results.length === 1 && (results[0] as any).integrity_check === 'ok') {
-        return 'ok';
+      return 'ok';
     }
     return JSON.stringify(results, null, 2);
   },
 
-  runVacuum(): void {
-    db.exec('VACUUM;');
+  runVacuum(workspaceId?: string): void {
+    const { connection } = resolveConnection(workspaceId);
+    connection.exec('VACUUM;');
   },
 
-  getDatabaseStats(): DatabaseStats {
-    const fileSize = statSync(DB_PATH).size;
-    const pageSize = db.pragma('page_size', { simple: true }) as number;
-    const pageCount = db.pragma('page_count', { simple: true }) as number;
-    const schemaVersion = db.pragma('schema_version', { simple: true }) as number;
+  getDatabaseStats(workspaceId?: string): DatabaseStats {
+    const { connection, workspace } = resolveConnection(workspaceId);
+    const dbPath = getWorkspaceDbPath(workspace);
+    const fileSize = statSync(dbPath).size;
+    const pageSize = connection.pragma('page_size', { simple: true }) as number;
+    const pageCount = connection.pragma('page_count', { simple: true }) as number;
+    const schemaVersion = connection.pragma('schema_version', { simple: true }) as number;
 
-    const tableNames = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`).all() as {name: string}[];
+    const tableNames = connection.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`).all() as { name: string }[];
 
     const tables = tableNames.map(({ name }) => {
-        const rowCountResult = db.prepare(`SELECT COUNT(*) as count FROM "${name}"`).get() as { count: number };
-        const indexes = db.prepare(`PRAGMA index_list("${name}")`).all() as {name: string}[];
+      const rowCountResult = connection.prepare(`SELECT COUNT(*) as count FROM "${name}"`).get() as { count: number };
+      const indexes = connection.prepare(`PRAGMA index_list("${name}")`).all() as { name: string }[];
 
-        return {
-            name,
-            rowCount: rowCountResult.count,
-            indexes: indexes.map(i => i.name)
-        };
+      return {
+        name,
+        rowCount: rowCountResult.count,
+        indexes: indexes.map(i => i.name),
+      };
     });
 
     return {
@@ -682,9 +1205,10 @@ export const databaseService = {
     };
   },
 
+  events: serviceEvents,
+
   close() {
-    if (db) {
-      db.close();
-    }
+    closeAllConnections();
+    activeWorkspaceId = null;
   }
 };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,19 +2,39 @@ import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // --- Database ---
-  dbQuery: (sql: string, params?: any[]) => ipcRenderer.invoke('db:query', sql, params),
-  dbGet: (sql: string, params?: any[]) => ipcRenderer.invoke('db:get', sql, params),
-  dbRun: (sql: string, params?: any[]) => ipcRenderer.invoke('db:run', sql, params),
+  dbQuery: (sql: string, params?: any[], workspaceId?: string) => ipcRenderer.invoke('db:query', sql, params, workspaceId),
+  dbGet: (sql: string, params?: any[], workspaceId?: string) => ipcRenderer.invoke('db:get', sql, params, workspaceId),
+  dbRun: (sql: string, params?: any[], workspaceId?: string) => ipcRenderer.invoke('db:run', sql, params, workspaceId),
   dbIsNew: () => ipcRenderer.invoke('db:is-new'),
   dbMigrateFromJson: (data: any) => ipcRenderer.invoke('db:migrate-from-json', data),
-  dbDuplicateNodes: (nodeIds: string[]) => ipcRenderer.invoke('db:duplicate-nodes', nodeIds),
-  dbDeleteVersions: (documentId: number, versionIds: number[]) => ipcRenderer.invoke('db:delete-versions', documentId, versionIds),
-  dbBackup: () => ipcRenderer.invoke('db:backup'),
-  dbIntegrityCheck: () => ipcRenderer.invoke('db:integrity-check'),
-  dbVacuum: () => ipcRenderer.invoke('db:vacuum'),
-  dbGetStats: () => ipcRenderer.invoke('db:get-stats'),
-  dbGetPath: () => ipcRenderer.invoke('db:get-path'),
-  dbImportFiles: (filesData: any[], targetParentId: string | null) => ipcRenderer.invoke('db:import-files', filesData, targetParentId),
+  dbDuplicateNodes: (nodeIds: string[], workspaceId?: string) => ipcRenderer.invoke('db:duplicate-nodes', nodeIds, workspaceId),
+  dbDeleteVersions: (documentId: number, versionIds: number[], workspaceId?: string) =>
+    ipcRenderer.invoke('db:delete-versions', documentId, versionIds, workspaceId),
+  dbBackup: (workspaceId?: string) => ipcRenderer.invoke('db:backup', workspaceId),
+  dbIntegrityCheck: (workspaceId?: string) => ipcRenderer.invoke('db:integrity-check', workspaceId),
+  dbVacuum: (workspaceId?: string) => ipcRenderer.invoke('db:vacuum', workspaceId),
+  dbGetStats: (workspaceId?: string) => ipcRenderer.invoke('db:get-stats', workspaceId),
+  dbGetPath: (workspaceId?: string) => ipcRenderer.invoke('db:get-path', workspaceId),
+  dbListWorkspaces: () => ipcRenderer.invoke('db:list-workspaces'),
+  dbCreateWorkspace: (name: string) => ipcRenderer.invoke('db:create-workspace', name),
+  dbRenameWorkspace: (workspaceId: string, newName: string) => ipcRenderer.invoke('db:rename-workspace', workspaceId, newName),
+  dbDeleteWorkspace: (workspaceId: string) => ipcRenderer.invoke('db:delete-workspace', workspaceId),
+  dbSwitchWorkspace: (workspaceId: string) => ipcRenderer.invoke('db:switch-workspace', workspaceId),
+  dbGetActiveWorkspace: () => ipcRenderer.invoke('db:get-active-workspace'),
+  dbTransferNodes: (nodeIds: string[], targetWorkspaceId: string, targetParentId: string | null, sourceWorkspaceId?: string) =>
+    ipcRenderer.invoke('db:transfer-nodes', nodeIds, targetWorkspaceId, targetParentId, sourceWorkspaceId),
+  dbOpenWorkspaceConnection: (workspaceId: string) => ipcRenderer.invoke('db:open-workspace-connection', workspaceId),
+  dbCloseWorkspaceConnection: (workspaceId: string) => ipcRenderer.invoke('db:close-workspace-connection', workspaceId),
+  dbRefreshWorkspaceConnection: (workspaceId: string) => ipcRenderer.invoke('db:refresh-workspace-connection', workspaceId),
+  dbOnWorkspaceEvent: (callback: (event: any) => void) => {
+    const handler = (_: IpcRendererEvent, payload: any) => callback(payload);
+    ipcRenderer.on('db:workspace-event', handler);
+    return () => {
+      ipcRenderer.removeListener('db:workspace-event', handler);
+    };
+  },
+  dbImportFiles: (filesData: any[], targetParentId: string | null, workspaceId?: string) =>
+    ipcRenderer.invoke('db:import-files', filesData, targetParentId, workspaceId),
 
   // --- Migration-related FS access ---
   legacyFileExists: (filename: string) => ipcRenderer.invoke('fs:legacy-file-exists', filename),

--- a/hooks/useNodes.ts
+++ b/hooks/useNodes.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import type { Node, ViewMode, ImportedNodeSummary } from '../types';
 import { repository } from '../services/repository';
 import { useLogger } from './useLogger';
+import { useWorkspaceEvents } from './useWorkspaceEvents';
 
 export const useNodes = () => {
   const { addLog } = useLogger();
@@ -24,6 +25,20 @@ export const useNodes = () => {
   useEffect(() => {
     refreshNodes();
   }, [refreshNodes]);
+
+  const activeWorkspaceId = nodes[0]?.workspaceId ?? null;
+
+  useWorkspaceEvents(
+    event => {
+      if (event.type === 'workspace-activated') {
+        refreshNodes();
+      }
+      if (event.type === 'workspace-closed' && activeWorkspaceId && activeWorkspaceId === event.workspace.workspaceId) {
+        setNodes([]);
+      }
+    },
+    [refreshNodes, activeWorkspaceId],
+  );
 
   const addNode = useCallback(async (node: Omit<Node, 'node_id' | 'sort_order' | 'created_at' | 'updated_at'>): Promise<Node> => {
     const newNode = await repository.addNode(node);

--- a/hooks/usePrompts.ts
+++ b/hooks/usePrompts.ts
@@ -15,6 +15,7 @@ const nodeToDocumentOrFolder = (node: Node): DocumentOrFolder => ({
   createdAt: node.created_at,
   updatedAt: node.updated_at,
   parentId: node.parent_id,
+  workspaceId: node.workspaceId,
   doc_type: node.document?.doc_type,
   language_hint: node.document?.language_hint,
   default_view_mode: node.document?.default_view_mode,

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SETTINGS } from '../constants';
 import { repository } from '../services/repository';
 import { useLogger } from './useLogger';
 import { llmDiscoveryService } from '../services/llmDiscoveryService';
+import { useWorkspaceEvents } from './useWorkspaceEvents';
 
 // Fix: Use optional chaining which is now type-safe with the global declaration.
 const isElectron = window.electronAPI;
@@ -13,48 +14,58 @@ export const useSettings = () => {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [loaded, setLoaded] = useState(false);
 
-  useEffect(() => {
-    const loadAndEnhanceSettings = async () => {
-      let loadedSettingsFromDB = await repository.getAllSettings();
-      
-      // If no settings in DB, this is a true first run.
-      if (Object.keys(loadedSettingsFromDB).length === 0) {
-        await repository.saveAllSettings(DEFAULT_SETTINGS);
-        loadedSettingsFromDB = DEFAULT_SETTINGS;
-        addLog('INFO', 'Initialized default settings in the database.');
-      }
-      
-      // Merge with defaults to ensure all properties exist for existing users after an update.
-      const mergedSettings = { ...DEFAULT_SETTINGS, ...loadedSettingsFromDB };
+  const loadAndEnhanceSettings = useCallback(async () => {
+    let loadedSettingsFromDB = await repository.getAllSettings();
 
-      // If provider name is missing but URL is present, try to discover it.
-      if (mergedSettings.llmProviderUrl && !mergedSettings.llmProviderName) {
-          addLog('DEBUG', 'LLM provider name is missing, attempting to discover it.');
-          try {
-              const services = await llmDiscoveryService.discoverServices();
-              const matchingService = services.find(s => s.generateUrl === mergedSettings.llmProviderUrl);
-              if (matchingService) {
-                  mergedSettings.llmProviderName = matchingService.name;
-                  mergedSettings.apiType = matchingService.apiType;
-                  addLog('INFO', `Discovered and set provider name to: "${matchingService.name}"`);
-                  // Save the enhanced settings back
-                  await repository.saveAllSettings(mergedSettings);
-              } else {
-                  addLog('WARNING', `Could not find a matching running service for the saved URL: ${mergedSettings.llmProviderUrl}`);
-              }
-          } catch (error) {
-              const message = error instanceof Error ? error.message : String(error);
-              addLog('ERROR', `Error during settings enhancement discovery: ${message}`);
-          }
-      }
+    // If no settings in DB, this is a true first run.
+    if (Object.keys(loadedSettingsFromDB).length === 0) {
+      await repository.saveAllSettings(DEFAULT_SETTINGS);
+      loadedSettingsFromDB = DEFAULT_SETTINGS;
+      addLog('INFO', 'Initialized default settings in the database.');
+    }
 
-      setSettings(mergedSettings);
-      setLoaded(true);
-      addLog('DEBUG', 'Settings loaded from database and merged with defaults.');
-    };
+    // Merge with defaults to ensure all properties exist for existing users after an update.
+    const mergedSettings = { ...DEFAULT_SETTINGS, ...loadedSettingsFromDB };
 
-    loadAndEnhanceSettings();
+    // If provider name is missing but URL is present, try to discover it.
+    if (mergedSettings.llmProviderUrl && !mergedSettings.llmProviderName) {
+        addLog('DEBUG', 'LLM provider name is missing, attempting to discover it.');
+        try {
+            const services = await llmDiscoveryService.discoverServices();
+            const matchingService = services.find(s => s.generateUrl === mergedSettings.llmProviderUrl);
+            if (matchingService) {
+                mergedSettings.llmProviderName = matchingService.name;
+                mergedSettings.apiType = matchingService.apiType;
+                addLog('INFO', `Discovered and set provider name to: "${matchingService.name}"`);
+                // Save the enhanced settings back
+                await repository.saveAllSettings(mergedSettings);
+            } else {
+                addLog('WARNING', `Could not find a matching running service for the saved URL: ${mergedSettings.llmProviderUrl}`);
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            addLog('ERROR', `Error during settings enhancement discovery: ${message}`);
+        }
+    }
+
+    setSettings(mergedSettings);
+    setLoaded(true);
+    addLog('DEBUG', 'Settings loaded from database and merged with defaults.');
   }, [addLog]);
+
+  useEffect(() => {
+    loadAndEnhanceSettings();
+  }, [loadAndEnhanceSettings]);
+
+  useWorkspaceEvents(
+    event => {
+      if (event.type === 'workspace-activated') {
+        setLoaded(false);
+        loadAndEnhanceSettings();
+      }
+    },
+    [loadAndEnhanceSettings],
+  );
 
   // Effect to notify main process of prerelease setting changes
   useEffect(() => {

--- a/hooks/useTemplates.ts
+++ b/hooks/useTemplates.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import type { DocumentTemplate } from '../types';
 import { repository } from '../services/repository';
 import { useLogger } from './useLogger';
+import { useWorkspaceEvents } from './useWorkspaceEvents';
 
 export const useTemplates = () => {
   const { addLog } = useLogger();
@@ -22,6 +23,15 @@ export const useTemplates = () => {
     // We just need to load them.
     refreshTemplates();
   }, [refreshTemplates]);
+
+  useWorkspaceEvents(
+    event => {
+      if (event.type === 'workspace-activated') {
+        refreshTemplates();
+      }
+    },
+    [refreshTemplates],
+  );
 
   const addTemplate = useCallback(async () => {
     const newTemplate = await repository.addTemplate({

--- a/hooks/useWorkspaceEvents.ts
+++ b/hooks/useWorkspaceEvents.ts
@@ -1,0 +1,18 @@
+import { useEffect, type DependencyList } from 'react';
+import type { WorkspaceConnectionEvent } from '../types';
+
+export const useWorkspaceEvents = (
+  handler: (event: WorkspaceConnectionEvent) => void,
+  deps: DependencyList = [],
+) => {
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.electronAPI?.dbOnWorkspaceEvent) {
+      return;
+    }
+    const unsubscribe = window.electronAPI.dbOnWorkspaceEvent(handler);
+    return () => {
+      unsubscribe?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};

--- a/services/repository.ts
+++ b/services/repository.ts
@@ -9,12 +9,114 @@ import type {
   ContentStore,
   ViewMode,
   ImportedNodeSummary,
+  WorkspaceInfo,
 } from '../types';
 import { cryptoService } from './cryptoService';
 import { DEFAULT_SETTINGS, EXAMPLE_TEMPLATES, LOCAL_STORAGE_KEYS } from '../constants';
 import { v4 as uuidv4 } from 'uuid';
 
 const isElectron = typeof window !== 'undefined' && !!window.electronAPI;
+
+let activeWorkspaceIdCache: string | null = null;
+let hasLoadedWorkspaceId = false;
+let workspaceEventSubscriptionRegistered = false;
+
+const updateActiveWorkspaceCache = (workspaceId: string | null) => {
+    activeWorkspaceIdCache = workspaceId;
+    hasLoadedWorkspaceId = true;
+};
+
+const ensureWorkspaceEventSubscription = () => {
+    if (!isElectron || workspaceEventSubscriptionRegistered) {
+        return;
+    }
+    const unsubscribe = window.electronAPI?.dbOnWorkspaceEvent?.(event => {
+        if (event.type === 'workspace-activated') {
+            updateActiveWorkspaceCache(event.workspace.workspaceId);
+        }
+        if (event.type === 'workspace-closed' && activeWorkspaceIdCache === event.workspace.workspaceId) {
+            updateActiveWorkspaceCache(null);
+        }
+    });
+    if (unsubscribe) {
+        workspaceEventSubscriptionRegistered = true;
+    }
+};
+
+const getActiveWorkspaceId = async (forceRefresh: boolean = false): Promise<string | null> => {
+    if (!isElectron || !window.electronAPI?.dbGetActiveWorkspace) {
+        return null;
+    }
+    ensureWorkspaceEventSubscription();
+    if (forceRefresh || !hasLoadedWorkspaceId) {
+        const active = await window.electronAPI.dbGetActiveWorkspace();
+        updateActiveWorkspaceCache(active?.workspaceId ?? null);
+    }
+    return activeWorkspaceIdCache;
+};
+
+const resolveWorkspaceId = async (workspaceId?: string | null): Promise<string | null> => {
+    if (workspaceId) {
+        return workspaceId;
+    }
+    return getActiveWorkspaceId();
+};
+
+const dbQuery = async <T = any>(sql: string, params: any[] = [], workspaceId?: string | null): Promise<T[]> => {
+    if (!window.electronAPI?.dbQuery) {
+        throw new Error('Database queries are not supported in this environment.');
+    }
+    const resolved = await resolveWorkspaceId(workspaceId);
+    return window.electronAPI.dbQuery(sql, params, resolved ?? undefined);
+};
+
+const dbGet = async <T = any>(sql: string, params: any[] = [], workspaceId?: string | null): Promise<T | undefined> => {
+    if (!window.electronAPI?.dbGet) {
+        throw new Error('Database reads are not supported in this environment.');
+    }
+    const resolved = await resolveWorkspaceId(workspaceId);
+    return window.electronAPI.dbGet(sql, params, resolved ?? undefined);
+};
+
+const dbRun = async (
+    sql: string,
+    params: any[] = [],
+    workspaceId?: string | null,
+): Promise<{ changes: number; lastInsertRowid: number | bigint }> => {
+    if (!window.electronAPI?.dbRun) {
+        throw new Error('Database mutations are not supported in this environment.');
+    }
+    const resolved = await resolveWorkspaceId(workspaceId);
+    return window.electronAPI.dbRun(sql, params, resolved ?? undefined);
+};
+
+const dbDuplicateNodes = async (nodeIds: string[], workspaceId?: string | null) => {
+    if (!window.electronAPI?.dbDuplicateNodes) {
+        throw new Error('Node duplication is not supported in this environment.');
+    }
+    const resolved = await resolveWorkspaceId(workspaceId);
+    return window.electronAPI.dbDuplicateNodes(nodeIds, resolved ?? undefined);
+};
+
+const dbDeleteVersions = async (documentId: number, versionIds: number[], workspaceId?: string | null) => {
+    if (!window.electronAPI?.dbDeleteVersions) {
+        throw new Error('Version deletion is not supported in this environment.');
+    }
+    const resolved = await resolveWorkspaceId(workspaceId);
+    return window.electronAPI.dbDeleteVersions(documentId, versionIds, resolved ?? undefined);
+};
+
+const dbImportFiles = async (
+    filesData: { path: string; name: string; content: string }[],
+    targetParentId: string | null,
+    workspaceId?: string | null,
+) => {
+    if (!window.electronAPI?.dbImportFiles) {
+        throw new Error('File import is not supported in this environment.');
+    }
+    const resolved = await resolveWorkspaceId(workspaceId);
+    return window.electronAPI.dbImportFiles(filesData, targetParentId, resolved ?? undefined);
+};
 
 type BrowserState = {
     nodes: Node[];
@@ -68,6 +170,7 @@ const createSampleBrowserState = (): BrowserState => {
         default_view_mode: 'split-vertical',
         current_version_id: versionId,
         content: sampleContent,
+        workspaceId: 'browser-preview',
     };
 
     const documentNode: Node = {
@@ -78,6 +181,7 @@ const createSampleBrowserState = (): BrowserState => {
         sort_order: 0,
         created_at: now,
         updated_at: now,
+        workspaceId: 'browser-preview',
         document,
     };
 
@@ -89,6 +193,7 @@ const createSampleBrowserState = (): BrowserState => {
         sort_order: 0,
         created_at: now,
         updated_at: now,
+        workspaceId: 'browser-preview',
         children: [documentNode],
     };
 
@@ -474,7 +579,8 @@ export const repository = {
         }
 
         if (!window.electronAPI) return [];
-        const flatNodes = await window.electronAPI.dbQuery(`
+        const workspaceId = await getActiveWorkspaceId();
+        const flatNodes = await dbQuery(`
             SELECT
                 n.*,
                 d.document_id, d.doc_type, d.language_hint, d.default_view_mode, d.current_version_id,
@@ -488,7 +594,7 @@ export const repository = {
             LEFT JOIN content_store cs ON dv.content_id = cs.content_id
             LEFT JOIN node_python_settings ps ON n.node_id = ps.node_id
             ORDER BY n.sort_order
-        `);
+        `, []);
         
         const nodesById = new Map<string, Node>();
         const rootNodes: Node[] = [];
@@ -502,6 +608,7 @@ export const repository = {
                 sort_order: record.sort_order,
                 created_at: record.created_at,
                 updated_at: record.updated_at,
+                workspaceId: workspaceId ?? 'unknown',
                 children: [],
                 document: record.document_id ? {
                     document_id: record.document_id,
@@ -511,6 +618,7 @@ export const repository = {
                     default_view_mode: record.default_view_mode,
                     current_version_id: record.current_version_id,
                     content: record.content,
+                    workspaceId: workspaceId ?? 'unknown',
                 } : undefined,
                 pythonSettings: record.python_env_id !== null || record.python_auto_detect_env !== null || record.python_last_run_id !== null ? {
                     nodeId: record.node_id,
@@ -574,8 +682,10 @@ export const repository = {
             ? sanitizedTerms.map(token => `${token}*`).join(' ')
             : term.replace(/["'`*^]/g, '');
 
+        const workspaceId = await getActiveWorkspaceId();
+
         try {
-            const rows = await window.electronAPI.dbQuery(
+            const rows = await dbQuery(
                 `
                 SELECT node_id, title, body
                 FROM document_search
@@ -584,6 +694,7 @@ export const repository = {
                 LIMIT ?
             `,
                 [ftsQuery, maxResults],
+                workspaceId,
             );
 
             const seen = new Set<string>();
@@ -607,7 +718,7 @@ export const repository = {
             const lowerTerm = term.toLowerCase();
             const pattern = `%${escapeForLikePattern(lowerTerm)}%`;
 
-            const rows = await window.electronAPI.dbQuery(
+            const rows = await dbQuery(
                 `
                 SELECT
                   d.node_id AS node_id,
@@ -623,8 +734,9 @@ export const repository = {
                   AND LOWER(cs.text_content) LIKE ? ESCAPE '\\'
                 ) OR LOWER(n.title) LIKE ? ESCAPE '\\'
                 LIMIT ?
-            `,
+              `,
                 [pattern, pattern, maxResults],
+                workspaceId,
             );
 
             const seen = new Set<string>();
@@ -658,6 +770,7 @@ export const repository = {
                 sort_order: 0,
                 created_at: now,
                 updated_at: now,
+                workspaceId: 'browser-preview',
             };
 
             let siblings: Node[];
@@ -688,6 +801,7 @@ export const repository = {
                     default_view_mode: nodeData.document?.default_view_mode ?? null,
                     current_version_id: versionId,
                     content,
+                    workspaceId: 'browser-preview',
                 };
                 state.docVersions[documentId] = [];
                 if (content && versionId) {
@@ -708,22 +822,26 @@ export const repository = {
 
         const newNodeId = uuidv4();
         const now = new Date().toISOString();
+        const workspaceId = await getActiveWorkspaceId();
 
-        const maxSortOrderResult = await window.electronAPI!.dbGet(
+        const maxSortOrderResult = await dbGet<{ max_order: number }>(
             `SELECT MAX(sort_order) as max_order FROM nodes WHERE parent_id ${nodeData.parent_id ? '= ?' : 'IS NULL'}`,
-            nodeData.parent_id ? [nodeData.parent_id] : []
+            nodeData.parent_id ? [nodeData.parent_id] : [],
+            workspaceId,
         );
         const sortOrder = (maxSortOrderResult?.max_order ?? -1) + 1;
 
-        await window.electronAPI!.dbRun(
+        await dbRun(
             `INSERT INTO nodes (node_id, parent_id, node_type, title, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-            [newNodeId, nodeData.parent_id, nodeData.node_type, nodeData.title, sortOrder, now, now]
+            [newNodeId, nodeData.parent_id, nodeData.node_type, nodeData.title, sortOrder, now, now],
+            workspaceId,
         );
 
         if (nodeData.node_type === 'document' && nodeData.document) {
-            const docRes = await window.electronAPI!.dbRun(
+            const docRes = await dbRun(
                 `INSERT INTO documents (node_id, doc_type, language_hint, default_view_mode) VALUES (?, ?, ?, ?)`,
-                [newNodeId, nodeData.document.doc_type, nodeData.document.language_hint, nodeData.document.default_view_mode ?? null]
+                [newNodeId, nodeData.document.doc_type, nodeData.document.language_hint, nodeData.document.default_view_mode ?? null],
+                workspaceId,
             );
             const documentId = docRes.lastInsertRowid;
 
@@ -732,8 +850,62 @@ export const repository = {
             }
         }
 
-        const createdNode = await window.electronAPI!.dbGet(`SELECT * FROM nodes WHERE node_id = ?`, [newNodeId]);
-        return createdNode as Node;
+        const record = await dbGet<any>(
+            `
+            SELECT
+              n.node_id,
+              n.parent_id,
+              n.node_type,
+              n.title,
+              n.sort_order,
+              n.created_at,
+              n.updated_at,
+              d.document_id,
+              d.doc_type,
+              d.language_hint,
+              d.default_view_mode,
+              d.current_version_id,
+              cs.text_content as content
+            FROM nodes n
+            LEFT JOIN documents d ON n.node_id = d.node_id
+            LEFT JOIN doc_versions dv ON d.current_version_id = dv.version_id
+            LEFT JOIN content_store cs ON dv.content_id = cs.content_id
+            WHERE n.node_id = ?
+        `,
+            [newNodeId],
+            workspaceId,
+        );
+
+        if (!record) {
+            throw new Error('Failed to load newly created node from the database.');
+        }
+
+        const effectiveWorkspaceId = workspaceId ?? 'unknown';
+
+        const createdNode: Node = {
+            node_id: record.node_id,
+            parent_id: record.parent_id,
+            node_type: record.node_type,
+            title: record.title,
+            sort_order: record.sort_order,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+            workspaceId: effectiveWorkspaceId,
+            document: record.document_id
+                ? {
+                      document_id: record.document_id,
+                      node_id: record.node_id,
+                      doc_type: record.doc_type,
+                      language_hint: record.language_hint,
+                      default_view_mode: record.default_view_mode,
+                      current_version_id: record.current_version_id,
+                      workspaceId: effectiveWorkspaceId,
+                      content: record.content ?? nodeData.document?.content,
+                  }
+                : undefined,
+        };
+
+        return createdNode;
     },
     async updateNode(nodeId: string, updates: Partial<Pick<Node, 'title' | 'parent_id'> & { language_hint?: string | null; default_view_mode?: ViewMode | null }>) {
         if (!isElectron) {
@@ -781,30 +953,34 @@ export const repository = {
         if (updates.parent_id !== undefined) nodeUpdates.parent_id = updates.parent_id;
 
         const now = new Date().toISOString();
+        const workspaceId = await getActiveWorkspaceId();
 
         if (Object.keys(nodeUpdates).length > 0) {
             const fields = Object.keys(nodeUpdates).map(key => `${key} = ?`).join(', ');
             const params = Object.values(nodeUpdates);
-            await window.electronAPI!.dbRun(
+            await dbRun(
                 `UPDATE nodes SET ${fields}, updated_at = ? WHERE node_id = ?`,
-                [...params, now, nodeId]
+                [...params, now, nodeId],
+                workspaceId,
             );
         }
 
         if (updates.language_hint !== undefined) {
-            await window.electronAPI!.dbRun(
+            await dbRun(
                 `UPDATE documents SET language_hint = ? WHERE node_id = ?`,
-                [updates.language_hint, nodeId]
+                [updates.language_hint, nodeId],
+                workspaceId,
             );
-            await window.electronAPI!.dbRun(`UPDATE nodes SET updated_at = ? WHERE node_id = ?`, [now, nodeId]);
+            await dbRun(`UPDATE nodes SET updated_at = ? WHERE node_id = ?`, [now, nodeId], workspaceId);
         }
 
         if (updates.default_view_mode !== undefined) {
-            await window.electronAPI!.dbRun(
+            await dbRun(
                 `UPDATE documents SET default_view_mode = ? WHERE node_id = ?`,
-                [updates.default_view_mode, nodeId]
+                [updates.default_view_mode, nodeId],
+                workspaceId,
             );
-            await window.electronAPI!.dbRun(`UPDATE nodes SET updated_at = ? WHERE node_id = ?`, [now, nodeId]);
+            await dbRun(`UPDATE nodes SET updated_at = ? WHERE node_id = ?`, [now, nodeId], workspaceId);
         }
     },
 
@@ -836,32 +1012,47 @@ export const repository = {
             return;
         }
 
+        const workspaceId = await getActiveWorkspaceId();
+
         let docId = documentId;
         if (!docId) {
-            const doc = await window.electronAPI!.dbGet(`SELECT document_id FROM documents WHERE node_id = ?`, [nodeId]);
+            const doc = await dbGet<{ document_id: number }>(
+                `SELECT document_id FROM documents WHERE node_id = ?`,
+                [nodeId],
+                workspaceId,
+            );
             if (!doc) throw new Error(`No document found for node ${nodeId}`);
             docId = doc.document_id;
         }
 
         const sha = await cryptoService.sha256(newContent);
 
-        let content = await window.electronAPI!.dbGet(`SELECT content_id FROM content_store WHERE sha256_hex = ?`, [sha]);
+        let content = await dbGet<{ content_id: number }>(
+            `SELECT content_id FROM content_store WHERE sha256_hex = ?`,
+            [sha],
+            workspaceId,
+        );
         let contentId;
         if (content) {
             contentId = content.content_id;
         } else {
-            const res = await window.electronAPI!.dbRun(`INSERT INTO content_store (sha256_hex, text_content) VALUES (?, ?)`, [sha, newContent]);
+            const res = await dbRun(
+                `INSERT INTO content_store (sha256_hex, text_content) VALUES (?, ?)`,
+                [sha, newContent],
+                workspaceId,
+            );
             contentId = res.lastInsertRowid;
         }
 
-        const versionRes = await window.electronAPI!.dbRun(
+        const versionRes = await dbRun(
             `INSERT INTO doc_versions (document_id, created_at, content_id) VALUES (?, ?, ?)`,
-            [docId, new Date().toISOString(), contentId]
+            [docId, new Date().toISOString(), contentId],
+            workspaceId,
         );
         const newVersionId = versionRes.lastInsertRowid;
 
-        await window.electronAPI!.dbRun(`UPDATE documents SET current_version_id = ? WHERE document_id = ?`, [newVersionId, docId]);
-        await window.electronAPI!.dbRun(`UPDATE nodes SET updated_at = ? WHERE node_id = ?`, [new Date().toISOString(), nodeId]);
+        await dbRun(`UPDATE documents SET current_version_id = ? WHERE document_id = ?`, [newVersionId, docId], workspaceId);
+        await dbRun(`UPDATE nodes SET updated_at = ? WHERE node_id = ?`, [new Date().toISOString(), nodeId], workspaceId);
     },
     
     async deleteNode(nodeId: string) {
@@ -880,7 +1071,8 @@ export const repository = {
             persistBrowserState(state);
             return;
         }
-        await window.electronAPI!.dbRun(`DELETE FROM nodes WHERE node_id = ?`, [nodeId]);
+        const workspaceId = await getActiveWorkspaceId();
+        await dbRun(`DELETE FROM nodes WHERE node_id = ?`, [nodeId], workspaceId);
     },
 
     async deleteNodes(nodeIds: string[]) {
@@ -892,7 +1084,8 @@ export const repository = {
             return;
         }
         const placeholders = nodeIds.map(() => '?').join(',');
-        await window.electronAPI!.dbRun(`DELETE FROM nodes WHERE node_id IN (${placeholders})`, nodeIds);
+        const workspaceId = await getActiveWorkspaceId();
+        await dbRun(`DELETE FROM nodes WHERE node_id IN (${placeholders})`, nodeIds, workspaceId);
     },
 
     async duplicateNodes(nodeIds: string[]) {
@@ -908,8 +1101,7 @@ export const repository = {
             persistBrowserState(state);
             return;
         }
-        if (!window.electronAPI?.dbDuplicateNodes) return;
-        const result = await window.electronAPI.dbDuplicateNodes(nodeIds);
+        const result = await dbDuplicateNodes(nodeIds);
         if (!result.success) {
             throw new Error(result.error || 'Failed to duplicate nodes in the main process.');
         }
@@ -965,13 +1157,16 @@ export const repository = {
             persistBrowserState(state);
             return;
         }
+        const workspaceId = await getActiveWorkspaceId();
+
         const parentId = position === 'inside'
             ? targetId
-            : (targetId ? (await window.electronAPI!.dbGet(`SELECT parent_id FROM nodes WHERE node_id = ?`, [targetId]))?.parent_id ?? null : null);
+            : (targetId ? (await dbGet<{ parent_id: string | null }>(`SELECT parent_id FROM nodes WHERE node_id = ?`, [targetId], workspaceId))?.parent_id ?? null : null);
 
-        const siblings = await window.electronAPI!.dbQuery(
+        const siblings = await dbQuery(
             `SELECT node_id, sort_order FROM nodes WHERE parent_id ${parentId ? '= ?' : 'IS NULL'} ORDER BY sort_order`,
-            parentId ? [parentId] : []
+            parentId ? [parentId] : [],
+            workspaceId,
         );
     
         const draggedIdSet = new Set(draggedIds);
@@ -1000,14 +1195,16 @@ export const repository = {
             const item = finalOrder[i];
             
             if (draggedIdSet.has(item.node_id)) {
-                await window.electronAPI!.dbRun(
+                await dbRun(
                     `UPDATE nodes SET parent_id = ?, sort_order = ? WHERE node_id = ?`,
-                    [parentId, i, item.node_id]
+                    [parentId, i, item.node_id],
+                    workspaceId,
                 );
             } else {
-                await window.electronAPI!.dbRun(
+                await dbRun(
                     `UPDATE nodes SET sort_order = ? WHERE node_id = ?`,
-                    [i, item.node_id]
+                    [i, item.node_id],
+                    workspaceId,
                 );
             }
         }
@@ -1021,14 +1218,15 @@ export const repository = {
             const versions = state.docVersions[node.document.document_id] ?? [];
             return cloneDocVersions(versions).sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
         }
-        return window.electronAPI!.dbQuery(`
+        const workspaceId = await getActiveWorkspaceId();
+        return dbQuery(`
             SELECT dv.version_id, dv.document_id, dv.created_at, dv.content_id, cs.text_content as content
             FROM doc_versions dv
             JOIN content_store cs ON dv.content_id = cs.content_id
             JOIN documents d ON dv.document_id = d.document_id
             WHERE d.node_id = ?
             ORDER BY dv.created_at DESC
-        `, [nodeId]);
+        `, [nodeId], workspaceId);
     },
 
     async deleteDocVersions(documentId: number, versionIds: number[]): Promise<void> {
@@ -1048,10 +1246,7 @@ export const repository = {
             persistBrowserState(state);
             return;
         }
-        if (!window.electronAPI?.dbDeleteVersions) {
-            throw new Error("Version deletion is not supported in this environment.");
-        }
-        const result = await window.electronAPI.dbDeleteVersions(documentId, versionIds);
+        const result = await dbDeleteVersions(documentId, versionIds);
         if (!result.success) {
             throw new Error(result.error || 'Failed to delete versions in main process.');
         }
@@ -1062,7 +1257,8 @@ export const repository = {
             const state = ensureBrowserState();
             return state.templates.map(template => ({ ...template }));
         }
-        return window.electronAPI!.dbQuery(`SELECT * FROM templates ORDER BY title`);
+        const workspaceId = await getActiveWorkspaceId();
+        return dbQuery(`SELECT * FROM templates ORDER BY title`, [], workspaceId);
     },
 
     async addTemplate(templateData: Omit<DocumentTemplate, 'template_id' | 'created_at' | 'updated_at'>): Promise<DocumentTemplate> {
@@ -1081,9 +1277,11 @@ export const repository = {
         }
         const newId = uuidv4();
         const now = new Date().toISOString();
-        await window.electronAPI!.dbRun(
+        const workspaceId = await getActiveWorkspaceId();
+        await dbRun(
             `INSERT INTO templates (template_id, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
-            [newId, templateData.title, templateData.content, now, now]
+            [newId, templateData.title, templateData.content, now, now],
+            workspaceId,
         );
         return { ...templateData, template_id: newId, created_at: now, updated_at: now };
     },
@@ -1100,9 +1298,11 @@ export const repository = {
         }
         const fields = Object.keys(updates).map(key => `${key} = ?`).join(', ');
         if(fields.length === 0) return;
-        await window.electronAPI!.dbRun(
+        const workspaceId = await getActiveWorkspaceId();
+        await dbRun(
             `UPDATE templates SET ${fields}, updated_at = ? WHERE template_id = ?`,
-            [...Object.values(updates), new Date().toISOString(), templateId]
+            [...Object.values(updates), new Date().toISOString(), templateId],
+            workspaceId,
         );
     },
 
@@ -1113,7 +1313,8 @@ export const repository = {
             persistBrowserState(state);
             return;
         }
-        await window.electronAPI!.dbRun(`DELETE FROM templates WHERE template_id = ?`, [templateId]);
+        const workspaceId = await getActiveWorkspaceId();
+        await dbRun(`DELETE FROM templates WHERE template_id = ?`, [templateId], workspaceId);
     },
 
     async deleteTemplates(templateIds: string[]) {
@@ -1125,7 +1326,8 @@ export const repository = {
             return;
         }
         const placeholders = templateIds.map(() => '?').join(',');
-        await window.electronAPI!.dbRun(`DELETE FROM templates WHERE template_id IN (${placeholders})`, templateIds);
+        const workspaceId = await getActiveWorkspaceId();
+        await dbRun(`DELETE FROM templates WHERE template_id IN (${placeholders})`, templateIds, workspaceId);
     },
 
     async getAllSettings(): Promise<Settings> {
@@ -1133,7 +1335,8 @@ export const repository = {
             const state = ensureBrowserState();
             return { ...state.settings };
         }
-        const rows = await window.electronAPI!.dbQuery(`SELECT key, value FROM settings`);
+        const workspaceId = await getActiveWorkspaceId();
+        const rows = await dbQuery(`SELECT key, value FROM settings`, [], workspaceId);
         const settings: any = {};
         for (const row of rows) {
             try {
@@ -1152,47 +1355,133 @@ export const repository = {
             persistBrowserState(state);
             return;
         }
+        const workspaceId = await getActiveWorkspaceId();
         for (const [key, value] of Object.entries(settings)) {
-            await window.electronAPI!.dbRun(
+            await dbRun(
                 `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
-                [key, JSON.stringify(value)]
+                [key, JSON.stringify(value)],
+                workspaceId,
             );
         }
     },
 
     async importFiles(filesData: {path: string, name: string, content: string}[], targetParentId: string | null): Promise<ImportedNodeSummary[]> {
-        if (!window.electronAPI?.dbImportFiles) {
-            throw new Error("File import is not supported in this environment.");
-        }
-        const result = await window.electronAPI.dbImportFiles(filesData, targetParentId);
+        const result = await dbImportFiles(filesData, targetParentId);
         if (!result.success) {
             throw new Error(result.error || 'Failed to import files in main process.');
         }
         return result.createdNodes ?? [];
     },
 
+    async listWorkspaces(): Promise<WorkspaceInfo[]> {
+        if (!isElectron || !window.electronAPI?.dbListWorkspaces) {
+            const now = new Date().toISOString();
+            return [{
+                workspaceId: 'browser-preview',
+                name: 'Browser Preview',
+                filePath: 'in-memory',
+                createdAt: now,
+                updatedAt: now,
+                lastOpenedAt: now,
+                isActive: true,
+                isOpen: true,
+            }];
+        }
+        return window.electronAPI.dbListWorkspaces();
+    },
+
+    async createWorkspace(name: string): Promise<WorkspaceInfo> {
+        if (!window.electronAPI?.dbCreateWorkspace) {
+            throw new Error('Workspace creation is not supported in this environment.');
+        }
+        return window.electronAPI.dbCreateWorkspace(name);
+    },
+
+    async renameWorkspace(workspaceId: string, newName: string): Promise<WorkspaceInfo> {
+        if (!window.electronAPI?.dbRenameWorkspace) {
+            throw new Error('Workspace renaming is not supported in this environment.');
+        }
+        return window.electronAPI.dbRenameWorkspace(workspaceId, newName);
+    },
+
+    async deleteWorkspace(workspaceId: string): Promise<{ success: boolean; error?: string }> {
+        if (!window.electronAPI?.dbDeleteWorkspace) {
+            throw new Error('Workspace deletion is not supported in this environment.');
+        }
+        return window.electronAPI.dbDeleteWorkspace(workspaceId);
+    },
+
+    async switchWorkspace(workspaceId: string): Promise<WorkspaceInfo> {
+        if (!window.electronAPI?.dbSwitchWorkspace) {
+            throw new Error('Workspace switching is not supported in this environment.');
+        }
+        const info = await window.electronAPI.dbSwitchWorkspace(workspaceId);
+        updateActiveWorkspaceCache(info.workspaceId);
+        const templates = await this.getAllTemplates();
+        if (templates.length === 0) {
+            await this.addDefaultTemplates();
+        }
+        return info;
+    },
+
+    async getActiveWorkspace(): Promise<WorkspaceInfo | null> {
+        if (!window.electronAPI?.dbGetActiveWorkspace) {
+            return {
+                workspaceId: 'browser-preview',
+                name: 'Browser Preview',
+                filePath: 'in-memory',
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                lastOpenedAt: new Date().toISOString(),
+                isActive: true,
+                isOpen: true,
+            };
+        }
+        const info = await window.electronAPI.dbGetActiveWorkspace();
+        updateActiveWorkspaceCache(info?.workspaceId ?? null);
+        return info;
+    },
+
+    async transferNodesToWorkspace(nodeIds: string[], targetWorkspaceId: string, targetParentId: string | null) {
+        if (!window.electronAPI?.dbTransferNodes) {
+            throw new Error('Transferring nodes between workspaces is not supported in this environment.');
+        }
+        const sourceWorkspaceId = await getActiveWorkspaceId();
+        return window.electronAPI.dbTransferNodes(
+            nodeIds,
+            targetWorkspaceId,
+            targetParentId,
+            sourceWorkspaceId ?? undefined,
+        );
+    },
+
     async getDbPath(): Promise<string> {
         if (!window.electronAPI?.dbGetPath) throw new Error("getDbPath not supported.");
-        return window.electronAPI.dbGetPath();
+        const workspaceId = await getActiveWorkspaceId();
+        return window.electronAPI.dbGetPath(workspaceId ?? undefined);
     },
 
     async backupDatabase() {
         if (!window.electronAPI?.dbBackup) throw new Error("Backup not supported.");
-        return window.electronAPI.dbBackup();
+        const workspaceId = await getActiveWorkspaceId();
+        return window.electronAPI.dbBackup(workspaceId ?? undefined);
     },
 
     async runIntegrityCheck() {
         if (!window.electronAPI?.dbIntegrityCheck) throw new Error("Integrity check not supported.");
-        return window.electronAPI.dbIntegrityCheck();
+        const workspaceId = await getActiveWorkspaceId();
+        return window.electronAPI.dbIntegrityCheck(workspaceId ?? undefined);
     },
 
     async runVacuum() {
         if (!window.electronAPI?.dbVacuum) throw new Error("Vacuum not supported.");
-        return window.electronAPI.dbVacuum();
+        const workspaceId = await getActiveWorkspaceId();
+        return window.electronAPI.dbVacuum(workspaceId ?? undefined);
     },
 
     async getDatabaseStats() {
         if (!window.electronAPI?.dbGetStats) throw new Error("DB stats not supported.");
-        return window.electronAPI.dbGetStats();
+        const workspaceId = await getActiveWorkspaceId();
+        return window.electronAPI.dbGetStats(workspaceId ?? undefined);
     }
 };


### PR DESCRIPTION
## Summary
- add workspace-aware database helpers and caching in the repository so every renderer call carries the active workspace id
- expose workspace connection events to renderer hooks and refresh nodes, templates, and settings when the active workspace changes
- extend preload bridge and shared types to pass optional workspace ids, include transfer source ids, and add a reusable useWorkspaceEvents hook

## Testing
- npm install *(fails: ENETUNREACH while downloading viz.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e538b037208332a23bc0843b0e80f1