### PR TITLE
Fix folder overview navigation from search results

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1063,14 +1063,21 @@ const MainApp: React.FC = () => {
         if (!target) {
             return;
         }
+
         ensureNodeVisible(target);
         setActiveTemplateId(null);
         setView('editor');
         setDocumentView('editor');
-        setActiveNodeId(nodeId);
+
+        if (target.type === 'document') {
+            activateDocumentTab(nodeId);
+        } else {
+            setActiveItem(nodeId);
+        }
+
         setSelectedIds(new Set([nodeId]));
         setLastClickedId(nodeId);
-    }, [items, ensureNodeVisible]);
+    }, [items, ensureNodeVisible, activateDocumentTab, setActiveItem]);
 
     const handleNewDocument = useCallback(async (parentId?: string | null) => {
         addLog('INFO', 'User action: Create New Document.');


### PR DESCRIPTION
## Summary
- ensure navigating to a folder overview search or recent item activates the correct node
- open document tabs or folder overviews when navigating from folder overview lists

## Testing
- `npm run build` *(fails: tailwindcss: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e629df502c83329bf7a4c1d0658c6d