### PR TITLE
feat: add new database creation workflow

### DIFF
--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -169,7 +169,7 @@ Accessed via the gear icon in the title bar. The settings are organized into cat
 - **Keyboard Shortcuts:** View and customize keyboard shortcuts for all major application actions. You can record a new key combination for any command.
 - **General:** Configure application behavior, like auto-saving logs, opting into pre-release updates, and choosing how PlantUML diagrams are rendered.
 - **Python:** Choose the interpreter used by the integrated runner. DocForge auto-detects local interpreters, can bootstrap a dedicated virtual environment per workspace, and exposes console preferences such as default working directory, automatic history retention, and whether runs open in split view.
-- **Database:** View detailed statistics about your local database file, and perform maintenance tasks such as creating a compressed backup, checking file integrity, and optimizing the database size (`VACUUM`).
+- **Database:** View detailed statistics about your local database file, and perform maintenance tasks such as creating a compressed backup, checking file integrity, optimizing the database size (`VACUUM`), or bootstrapping a brand new workspace database.
 - **Advanced:** View and edit the raw JSON configuration file using an interactive tree or a raw text editor, and import/export your settings.
 
 ### Info View

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ DocForge is a desktop application designed to streamline the process of creating
     - **Interface:** Switch between light and dark themes, adjust the UI scale, and choose from multiple icon sets.
     - **Keyboard Shortcuts:** Remap default shortcuts for core application commands to fit your preferences.
 - **Database Management:** A dedicated settings panel allows you to view database statistics, run integrity checks, and perform maintenance like backups and optimization.
+- **Workspace Bootstrap:** Create a brand new SQLite database from the status bar or settings to start fresh without leaving the app.
 - **Configurable Data Storage:** Choose a custom SQLite database location or reopen an existing workspace file from the settings panel.
 - **Comprehensive Action Logging**: Every user action is logged, providing a clear audit trail and making debugging easier.
 - **Offline First:** All your data is stored locally on your machine.

--- a/docs/FUNCTIONAL_MANUAL.md
+++ b/docs/FUNCTIONAL_MANUAL.md
@@ -169,7 +169,7 @@ Accessed via the gear icon in the title bar. The settings are organized into cat
 - **Keyboard Shortcuts:** View and customize keyboard shortcuts for all major application actions. You can record a new key combination for any command.
 - **General:** Configure application behavior, like auto-saving logs, opting into pre-release updates, and choosing how PlantUML diagrams are rendered.
 - **Python:** Choose the interpreter used by the integrated runner. DocForge auto-detects local interpreters, can bootstrap a dedicated virtual environment per workspace, and exposes console preferences such as default working directory, automatic history retention, and whether runs open in split view.
-- **Database:** View detailed statistics about your local database file, and perform maintenance tasks such as creating a compressed backup, checking file integrity, and optimizing the database size (`VACUUM`).
+- **Database:** View detailed statistics about your local database file, and perform maintenance tasks such as creating a compressed backup, checking file integrity, optimizing the database size (`VACUUM`), or bootstrapping a brand new workspace database.
 - **Advanced:** View and edit the raw JSON configuration file using an interactive tree or a raw text editor, and import/export your settings.
 
 ### Info View

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ DocForge is a desktop application designed to streamline the process of creating
     - **Interface:** Switch between light and dark themes, adjust the UI scale, and choose from multiple icon sets.
     - **Keyboard Shortcuts:** Remap default shortcuts for core application commands to fit your preferences.
 - **Database Management:** A dedicated settings panel allows you to view database statistics, run integrity checks, and perform maintenance like backups and optimization.
+- **Workspace Bootstrap:** Create a brand new SQLite database from the status bar or settings to start fresh without leaving the app.
 - **Configurable Data Storage:** Choose a custom SQLite database location or reopen an existing workspace file from the settings panel.
 - **Comprehensive Action Logging**: Every user action is logged, providing a clear audit trail and making debugging easier.
 - **Offline First:** All your data is stored locally on your machine.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -17,6 +17,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   dbGetStats: () => ipcRenderer.invoke('db:get-stats'),
   dbGetPath: () => ipcRenderer.invoke('db:get-path'),
   dbLoadFromPath: (filePath: string) => ipcRenderer.invoke('db:load-from-path', filePath),
+  dbCreateNew: () => ipcRenderer.invoke('db:create-new'),
   dbSelectAndLoad: () => ipcRenderer.invoke('db:select-and-load'),
   dbImportFiles: (filesData: any[], targetParentId: string | null) => ipcRenderer.invoke('db:import-files', filesData, targetParentId),
 

--- a/services/repository.ts
+++ b/services/repository.ts
@@ -1332,6 +1332,11 @@ export const repository = {
         return window.electronAPI.dbLoadFromPath(filePath);
     },
 
+    async createNewDatabase(): Promise<DatabaseLoadResult> {
+        if (!window.electronAPI?.dbCreateNew) throw new Error("Database creation not supported.");
+        return window.electronAPI.dbCreateNew();
+    },
+
     async selectDatabaseFile(): Promise<DatabaseLoadResult> {
         if (!window.electronAPI?.dbSelectAndLoad) throw new Error("Database selection not supported.");
         return window.electronAPI.dbSelectAndLoad();

--- a/types.ts
+++ b/types.ts
@@ -23,6 +23,7 @@ declare global {
       dbGetStats: () => Promise<{ success: boolean; stats?: DatabaseStats; error?: string }>;
       dbGetPath: () => Promise<string>;
       dbLoadFromPath: (filePath: string) => Promise<DatabaseLoadResult>;
+      dbCreateNew: () => Promise<DatabaseLoadResult>;
       dbSelectAndLoad: () => Promise<DatabaseLoadResult>;
       // FIX: Add missing `dbImportFiles` to the electronAPI type definition.
       dbImportFiles: (


### PR DESCRIPTION
## Summary
- add an Electron IPC handler and preload bridge that can create fresh SQLite databases
- surface "Create New Database" actions in the status bar menu and settings UI for a friendly workflow
- document the new workspace bootstrap capability across the README and manuals

## Testing
- npm run build *(fails: `tailwindcss` CLI missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e66f35cba08332977257dd8c572846