### PR TITLE
Refactor settings view into category pages

### DIFF
--- a/components/JsonEditor.tsx
+++ b/components/JsonEditor.tsx
@@ -7,9 +7,10 @@ interface JsonEditorProps {
   value: string;
   onChange: (value: string) => void;
   readOnly?: boolean;
+  className?: string;
 }
 
-const JsonEditor: React.FC<JsonEditorProps> = ({ value, onChange, readOnly = false }) => {
+const JsonEditor: React.FC<JsonEditorProps> = ({ value, onChange, readOnly = false, className }) => {
   const editorRef = useRef<HTMLTextAreaElement>(null);
   const preRef = useRef<HTMLPreElement>(null);
 
@@ -32,8 +33,10 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ value, onChange, readOnly = fal
   };
 
   return (
-    <div 
-      className="editor-container relative w-full rounded-lg bg-background border border-border-color focus-within:ring-2 focus-within:ring-primary focus-within:border-primary h-96"
+    <div
+      className={`editor-container relative w-full rounded-lg bg-background border border-border-color focus-within:ring-2 focus-within:ring-primary focus-within:border-primary ${
+        className ?? 'h-96'
+      }`}
     >
       <textarea
         ref={editorRef}

--- a/components/JsonEditor.tsx
+++ b/components/JsonEditor.tsx
@@ -33,12 +33,19 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ value, onChange, readOnly = fal
     }
   };
 
+  const combinedStyle: React.CSSProperties = {
+    minHeight: '24rem',
+    height: 'clamp(24rem, 70vh, 44rem)',
+    maxHeight: '44rem',
+    ...style,
+  };
+
   return (
     <div
       className={`editor-container relative w-full rounded-lg bg-background border border-border-color focus-within:ring-2 focus-within:ring-primary focus-within:border-primary ${
         className ?? ''
       }`}
-      style={{ height: 'clamp(24rem, 70vh, 44rem)', ...style }}
+      style={combinedStyle}
     >
       <textarea
         ref={editorRef}

--- a/components/JsonEditor.tsx
+++ b/components/JsonEditor.tsx
@@ -8,9 +8,10 @@ interface JsonEditorProps {
   onChange: (value: string) => void;
   readOnly?: boolean;
   className?: string;
+  style?: React.CSSProperties;
 }
 
-const JsonEditor: React.FC<JsonEditorProps> = ({ value, onChange, readOnly = false, className }) => {
+const JsonEditor: React.FC<JsonEditorProps> = ({ value, onChange, readOnly = false, className, style }) => {
   const editorRef = useRef<HTMLTextAreaElement>(null);
   const preRef = useRef<HTMLPreElement>(null);
 
@@ -35,8 +36,9 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ value, onChange, readOnly = fal
   return (
     <div
       className={`editor-container relative w-full rounded-lg bg-background border border-border-color focus-within:ring-2 focus-within:ring-primary focus-within:border-primary ${
-        className ?? 'h-96'
+        className ?? ''
       }`}
+      style={{ height: 'clamp(24rem, 70vh, 44rem)', ...style }}
     >
       <textarea
         ref={editorRef}

--- a/components/KeyboardShortcutsSection.tsx
+++ b/components/KeyboardShortcutsSection.tsx
@@ -8,10 +8,9 @@ interface KeyboardShortcutsSectionProps {
     settings: Settings;
     setCurrentSettings: React.Dispatch<React.SetStateAction<Settings>>;
     commands: Command[];
-    sectionRef: (el: HTMLDivElement | null) => void;
 }
 
-const KeyboardShortcutsSection: React.FC<KeyboardShortcutsSectionProps> = ({ settings, setCurrentSettings, commands, sectionRef }) => {
+const KeyboardShortcutsSection: React.FC<KeyboardShortcutsSectionProps> = ({ settings, setCurrentSettings, commands }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const editorCommands = useMemo(() => createMonacoCommands(), []);
     const combinedCommands = useMemo(() => [...commands, ...editorCommands], [commands, editorCommands]);
@@ -65,7 +64,7 @@ const KeyboardShortcutsSection: React.FC<KeyboardShortcutsSectionProps> = ({ set
     const hasEditorResults = Object.keys(groupedEditorCommands).length > 0;
 
     return (
-        <div id="shortcuts" ref={sectionRef} className="py-6">
+        <div className="py-6">
             <h2 className="text-lg font-semibold text-text-main mb-1">Keyboard Shortcuts</h2>
             <p className="text-xs text-text-secondary mb-4">Customize shortcuts for application commands and Monaco editor keybindings.</p>
             

--- a/components/SettingRow.tsx
+++ b/components/SettingRow.tsx
@@ -16,7 +16,7 @@ const SettingRow: React.FC<SettingRowProps> = ({ label, description, children, h
         </label>
         <p className="text-xs text-text-secondary mt-1">{description}</p>
       </div>
-      <div className="md:col-span-2 flex justify-start md:justify-end items-center w-full">
+      <div className="md:col-span-2 flex justify-start md:justify-end items-start w-full">
         {children}
       </div>
     </div>

--- a/components/SettingsTreeEditor.tsx
+++ b/components/SettingsTreeEditor.tsx
@@ -90,7 +90,12 @@ const SettingsTreeEditor: React.FC<SettingsTreeEditorProps> = ({ settings, onSet
   return (
     <div
       className={resolvedClassName}
-      style={{ height: 'clamp(24rem, 70vh, 44rem)', ...style }}
+      style={{
+        minHeight: '24rem',
+        height: 'clamp(24rem, 70vh, 44rem)',
+        maxHeight: '44rem',
+        ...style,
+      }}
     >
       {Object.entries(settings).map(([key, value]) => (
         <TreeNode key={key} nodeKey={key} nodeValue={value} path={[key]} level={0} onSettingChange={onSettingChange} />

--- a/components/SettingsTreeEditor.tsx
+++ b/components/SettingsTreeEditor.tsx
@@ -76,14 +76,21 @@ interface SettingsTreeEditorProps {
   settings: object;
   onSettingChange: (path: (string | number)[], value: any) => void;
   className?: string;
+  style?: React.CSSProperties;
 }
 
-const SettingsTreeEditor: React.FC<SettingsTreeEditorProps> = ({ settings, onSettingChange, className }) => {
+const SettingsTreeEditor: React.FC<SettingsTreeEditorProps> = ({ settings, onSettingChange, className, style }) => {
+  const resolvedClassName = [
+    'w-full p-2 rounded-lg bg-background border border-border-color overflow-y-auto',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <div
-      className={`p-2 rounded-lg bg-background border border-border-color overflow-y-auto ${
-        className ?? 'h-96'
-      }`}
+      className={resolvedClassName}
+      style={{ height: 'clamp(24rem, 70vh, 44rem)', ...style }}
     >
       {Object.entries(settings).map(([key, value]) => (
         <TreeNode key={key} nodeKey={key} nodeValue={value} path={[key]} level={0} onSettingChange={onSettingChange} />

--- a/components/SettingsTreeEditor.tsx
+++ b/components/SettingsTreeEditor.tsx
@@ -75,11 +75,16 @@ const TreeNode: React.FC<{
 interface SettingsTreeEditorProps {
   settings: object;
   onSettingChange: (path: (string | number)[], value: any) => void;
+  className?: string;
 }
 
-const SettingsTreeEditor: React.FC<SettingsTreeEditorProps> = ({ settings, onSettingChange }) => {
+const SettingsTreeEditor: React.FC<SettingsTreeEditorProps> = ({ settings, onSettingChange, className }) => {
   return (
-    <div className="p-2 rounded-lg bg-background border border-border-color h-96 overflow-y-auto">
+    <div
+      className={`p-2 rounded-lg bg-background border border-border-color overflow-y-auto ${
+        className ?? 'h-96'
+      }`}
+    >
       {Object.entries(settings).map(([key, value]) => (
         <TreeNode key={key} nodeKey={key} nodeValue={value} path={[key]} level={0} onSettingChange={onSettingChange} />
       ))}

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -391,7 +391,7 @@ const SettingsView: React.FC<SettingsViewProps> = ({
           </ul>
         </nav>
         <main className="flex-1 overflow-y-auto bg-secondary">
-          <div className="max-w-3xl mx-auto px-8 py-6">
+          <div className="w-full px-6 py-6">
             {renderActiveSection()}
           </div>
         </main>

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -436,9 +436,11 @@ const SettingsView: React.FC<SettingsViewProps> = ({
             ))}
           </ul>
         </nav>
-        <main className="flex-1 overflow-y-auto bg-secondary">
-          <div className="w-full px-6 py-6">
-            {renderActiveSection()}
+        <main className="flex-1 flex flex-col bg-secondary">
+          <div className="flex-1 overflow-y-auto px-6 py-3">
+            <div className="min-h-full flex flex-col">
+              {renderActiveSection()}
+            </div>
           </div>
         </main>
       </div>
@@ -509,7 +511,7 @@ const ProviderSettingsSection: React.FC<SectionProps & { discoveredServices: Dis
     const selectedService = discoveredServices.find(s => s.generateUrl === settings.llmProviderUrl);
 
     return (
-        <div className="py-6">
+        <section className="pt-2 pb-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">LLM Provider</h2>
             <div className="space-y-6">
                 <SettingRow label="Detect Services" description="Scan for locally running LLM services like Ollama and LM Studio.">
@@ -552,7 +554,7 @@ const ProviderSettingsSection: React.FC<SectionProps & { discoveredServices: Dis
                     </div>
                 </SettingRow>
             </div>
-        </div>
+        </section>
     );
 };
 
@@ -583,7 +585,7 @@ const AppearanceSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCu
 
 
     return (
-        <div className="py-6">
+        <section className="pt-2 pb-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">Appearance</h2>
             <div className="space-y-6">
                 <SettingRow label="Interface Scale" description="Adjust the size of all UI elements in the application.">
@@ -873,7 +875,7 @@ const AppearanceSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCu
                   </div>
                 </SettingRow>
             </div>
-        </div>
+        </section>
     );
 };
 
@@ -1113,7 +1115,7 @@ const PythonSettingsSection: React.FC<PythonSectionProps> = ({ settings, setCurr
   const interpreterValue = formState.useCustomInterpreter ? 'custom' : formState.interpreterPath;
 
   return (
-    <div className="py-6">
+    <section className="pt-2 pb-6">
       <h2 className="text-lg font-semibold text-text-main mb-4">Python Execution</h2>
       <p className="text-xs text-text-secondary max-w-3xl mb-6">
         Configure how DocForge prepares isolated Python environments. These defaults are applied when auto-creating a virtual
@@ -1378,7 +1380,7 @@ requests"
           </form>
         </Modal>
       )}
-    </div>
+    </section>
   );
 };
 
@@ -1386,7 +1388,7 @@ const GeneralSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurre
     const isOfflineRendererAvailable = typeof window !== 'undefined' && !!window.electronAPI?.renderPlantUML;
     const offlineRendererMessage = 'Offline rendering requires the desktop application with a local Java runtime.';
     return (
-        <div className="py-6">
+        <section className="pt-2 pb-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">General</h2>
             <div className="space-y-6">
                 <SettingRow htmlFor="allowPrerelease" label="Receive Pre-releases" description="Get notified about new beta versions and test features early.">
@@ -1421,7 +1423,7 @@ const GeneralSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurre
                     </div>
                 </SettingRow>
             </div>
-        </div>
+        </section>
     );
 };
 
@@ -1575,7 +1577,7 @@ const DatabaseSettingsSection: React.FC = () => {
     };
 
     return (
-        <div className="py-6">
+        <section className="pt-2 pb-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">Database Management</h2>
             <div className="space-y-6">
                 <SettingRow label="Database File" description="This file contains all your documents, folders, and history.">
@@ -1660,7 +1662,7 @@ const DatabaseSettingsSection: React.FC = () => {
                     )}
                 </SettingRow>
             </div>
-        </div>
+        </section>
     );
 };
 
@@ -1800,9 +1802,9 @@ const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurr
     }, [addLog, applyImportedSettings]);
 
     return (
-        <div className="py-6">
+        <section className="flex flex-col min-h-full pt-2 pb-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">Advanced</h2>
-            <div className="space-y-6">
+            <div className="flex flex-col gap-6 flex-1 min-h-0">
                 <SettingRow label="Settings Transfer" description="Export the current configuration or import it from a JSON file.">
                     <div className="flex flex-col gap-3">
                         <div className="flex flex-wrap gap-2">
@@ -1828,8 +1830,8 @@ const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurr
                     </div>
                 </SettingRow>
                 <SettingRow label="Settings Editor" description="Edit settings using an interactive tree or raw JSON for full control.">
-                    <div className="w-full">
-                        <div className="flex justify-end mb-2">
+                    <div className="flex flex-col gap-3 w-full flex-1 min-h-0 self-stretch">
+                        <div className="flex justify-end">
                             <div className="flex items-center p-1 bg-background rounded-lg border border-border-color">
                                 <button
                                     onClick={() => setMode('tree')}
@@ -1845,19 +1847,28 @@ const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurr
                                 </button>
                             </div>
                         </div>
-
-                        {mode === 'tree' ? (
-                            <SettingsTreeEditor settings={settings} onSettingChange={handleSettingChange} />
-                        ) : (
-                            <div>
-                                <JsonEditor value={jsonString} onChange={handleJsonChange} />
-                                {jsonError && <p className="text-sm text-destructive-text mt-2">{jsonError}</p>}
-                            </div>
-                        )}
+                        <div className="flex-1 min-h-0 flex flex-col gap-2">
+                            {mode === 'tree' ? (
+                                <SettingsTreeEditor
+                                    settings={settings}
+                                    onSettingChange={handleSettingChange}
+                                    className="flex-1 min-h-[24rem]"
+                                />
+                            ) : (
+                                <>
+                                    <JsonEditor
+                                        value={jsonString}
+                                        onChange={handleJsonChange}
+                                        className="flex-1 min-h-[24rem]"
+                                    />
+                                    {jsonError && <p className="text-sm text-destructive-text">{jsonError}</p>}
+                                </>
+                            )}
+                        </div>
                     </div>
                 </SettingRow>
             </div>
-        </div>
+        </section>
     );
 };
 

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -390,7 +390,7 @@ const SettingsView: React.FC<SettingsViewProps> = ({
             ))}
           </ul>
         </nav>
-        <main className="flex-1 overflow-y-auto bg-background">
+        <main className="flex-1 overflow-y-auto bg-secondary">
           <div className="max-w-3xl mx-auto px-8 py-6">
             {renderActiveSection()}
           </div>

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -308,8 +308,6 @@ const SettingsView: React.FC<SettingsViewProps> = ({
     [visibleCategory]
   );
 
-  const ActiveIcon = activeCategory.icon;
-
   const renderActiveSection = () => {
     switch (activeCategory.id) {
       case 'provider':
@@ -392,18 +390,9 @@ const SettingsView: React.FC<SettingsViewProps> = ({
             ))}
           </ul>
         </nav>
-        <main className="flex-1 overflow-y-auto bg-secondary">
-          <div className="max-w-3xl mx-auto px-8 py-6 space-y-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <h2 className="text-base font-semibold text-text-main">{activeCategory.label}</h2>
-                <p className="text-xs text-text-secondary">Fine-tune options for this category.</p>
-              </div>
-              <ActiveIcon className="w-6 h-6 text-primary" />
-            </div>
-            <div className="border border-border-color/70 rounded-lg bg-background/60">
-              {renderActiveSection()}
-            </div>
+        <main className="flex-1 overflow-y-auto bg-background">
+          <div className="max-w-3xl mx-auto px-8 py-6">
+            {renderActiveSection()}
           </div>
         </main>
       </div>

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -344,6 +344,7 @@ const SettingsView: React.FC<SettingsViewProps> = ({
 
       if (nextIndex !== index) {
         event.preventDefault();
+        handleNavClick(categories[nextIndex].id);
         navButtonRefs.current[nextIndex]?.focus();
       }
     },
@@ -423,7 +424,7 @@ const SettingsView: React.FC<SettingsViewProps> = ({
                   }}
                   onKeyDown={(event) => handleNavKeyDown(event, index)}
                   onClick={() => handleNavClick(id)}
-                  className={`w-full flex items-center gap-3 px-2 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                  className={`w-full flex items-center gap-3 px-2 py-1.5 text-xs font-medium rounded-md transition-colors focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0 ${
                     visibleCategory === id
                       ? 'bg-primary/10 text-primary'
                       : 'text-text-secondary hover:bg-border-color/50 hover:text-text-main'

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -1674,6 +1674,7 @@ const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurr
     const [jsonError, setJsonError] = useState<string | null>(null);
     const [mode, setMode] = useState<'tree' | 'json'>('tree');
     const [transferStatus, setTransferStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+    const editorSurfaceStyle = useMemo<React.CSSProperties>(() => ({ height: 'clamp(24rem, 70vh, 44rem)' }), []);
 
     useEffect(() => {
         setJsonString(JSON.stringify(settings, null, 2));
@@ -1853,14 +1854,16 @@ const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurr
                                 <SettingsTreeEditor
                                     settings={settings}
                                     onSettingChange={handleSettingChange}
-                                    className="flex-1 min-h-[24rem]"
+                                    className="flex-1"
+                                    style={editorSurfaceStyle}
                                 />
                             ) : (
                                 <>
                                     <JsonEditor
                                         value={jsonString}
                                         onChange={handleJsonChange}
-                                        className="flex-1 min-h-[24rem]"
+                                        className="flex-1"
+                                        style={editorSurfaceStyle}
                                     />
                                     {jsonError && <p className="text-sm text-destructive-text">{jsonError}</p>}
                                 </>

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -1674,7 +1674,14 @@ const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurr
     const [jsonError, setJsonError] = useState<string | null>(null);
     const [mode, setMode] = useState<'tree' | 'json'>('tree');
     const [transferStatus, setTransferStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
-    const editorSurfaceStyle = useMemo<React.CSSProperties>(() => ({ height: 'clamp(24rem, 70vh, 44rem)' }), []);
+    const editorSurfaceStyle = useMemo<React.CSSProperties>(
+        () => ({
+            minHeight: '24rem',
+            height: 'clamp(24rem, 70vh, 44rem)',
+            maxHeight: '44rem',
+        }),
+        [],
+    );
 
     useEffect(() => {
         setJsonString(JSON.stringify(settings, null, 2));

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -284,9 +284,6 @@ const SettingsView: React.FC<SettingsViewProps> = ({
   const { addLog } = useLogger();
   const [pythonValidationError, setPythonValidationError] = useState<string | null>(null);
 
-  const sectionRefs = useRef<Partial<Record<SettingsCategory, HTMLDivElement | null>>>({});
-  const mainPanelRef = useRef<HTMLElement>(null);
-
   useEffect(() => {
     setCurrentSettings(settings);
   }, [settings]);
@@ -295,49 +292,70 @@ const SettingsView: React.FC<SettingsViewProps> = ({
     setIsDirty(JSON.stringify(settings) !== JSON.stringify(currentSettings));
   }, [settings, currentSettings]);
 
-  useEffect(() => {
-    const panel = mainPanelRef.current;
-    if (!panel) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setVisibleCategory(entry.target.id as SettingsCategory);
-          }
-        });
-      },
-      {
-        root: panel,
-        rootMargin: '-40% 0px -60% 0px',
-        threshold: 0,
-      }
-    );
-
-    const sections = Object.values(sectionRefs.current).filter(
-      (section): section is HTMLDivElement => Boolean(section)
-    );
-    sections.forEach((section) => observer.observe(section));
-
-    return () => {
-      sections.forEach((section) => observer.unobserve(section));
-      observer.disconnect();
-    };
-  }, []);
-
   const handleSave = useCallback(() => {
     addLog('INFO', 'User action: Save settings.');
     onSave(currentSettings);
   }, [addLog, onSave, currentSettings]);
 
   const handleNavClick = useCallback((id: SettingsCategory) => {
-    sectionRefs.current[id]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     setVisibleCategory(id);
   }, []);
 
   const isSaveDisabled = !isDirty || !!pythonValidationError;
+
+  const activeCategory = useMemo(
+    () => categories.find((category) => category.id === visibleCategory) ?? categories[0],
+    [visibleCategory]
+  );
+
+  const ActiveIcon = activeCategory.icon;
+
+  const renderActiveSection = () => {
+    switch (activeCategory.id) {
+      case 'provider':
+        return (
+          <ProviderSettingsSection
+            {...{
+              settings: currentSettings,
+              setCurrentSettings,
+              discoveredServices,
+              onDetectServices,
+              isDetecting,
+            }}
+          />
+        );
+      case 'appearance':
+        return <AppearanceSettingsSection {...{ settings: currentSettings, setCurrentSettings }} />;
+      case 'shortcuts':
+        return (
+          <KeyboardShortcutsSection
+            {...{
+              settings: currentSettings,
+              setCurrentSettings,
+              commands,
+            }}
+          />
+        );
+      case 'python':
+        return (
+          <PythonSettingsSection
+            {...{
+              settings: currentSettings,
+              setCurrentSettings,
+              onValidationChange: setPythonValidationError,
+            }}
+          />
+        );
+      case 'general':
+        return <GeneralSettingsSection {...{ settings: currentSettings, setCurrentSettings }} />;
+      case 'database':
+        return <DatabaseSettingsSection />;
+      case 'advanced':
+        return <AdvancedSettingsSection {...{ settings: currentSettings, setCurrentSettings }} />;
+      default:
+        return null;
+    }
+  };
 
   return (
     <div className="flex-1 flex flex-col bg-background h-full">
@@ -374,56 +392,18 @@ const SettingsView: React.FC<SettingsViewProps> = ({
             ))}
           </ul>
         </nav>
-        <main ref={mainPanelRef} className="flex-1 overflow-y-auto bg-secondary">
-          <div className="max-w-4xl mx-auto px-8 divide-y divide-border-color/50">
-            <ProviderSettingsSection
-              {...{
-                settings: currentSettings,
-                setCurrentSettings,
-                discoveredServices,
-                onDetectServices,
-                isDetecting,
-                sectionRef: (el) => (sectionRefs.current.provider = el),
-              }}
-            />
-            <AppearanceSettingsSection
-              {...{
-                settings: currentSettings,
-                setCurrentSettings,
-                sectionRef: (el) => (sectionRefs.current.appearance = el),
-              }}
-            />
-            <KeyboardShortcutsSection
-              {...{
-                settings: currentSettings,
-                setCurrentSettings,
-                commands,
-                sectionRef: (el) => (sectionRefs.current.shortcuts = el),
-              }}
-            />
-            <PythonSettingsSection
-              {...{
-                settings: currentSettings,
-                setCurrentSettings,
-                sectionRef: (el) => (sectionRefs.current.python = el),
-                onValidationChange: setPythonValidationError,
-              }}
-            />
-            <GeneralSettingsSection
-              {...{
-                settings: currentSettings,
-                setCurrentSettings,
-                sectionRef: (el) => (sectionRefs.current.general = el),
-              }}
-            />
-            <DatabaseSettingsSection {...{ sectionRef: (el) => (sectionRefs.current.database = el) }} />
-            <AdvancedSettingsSection
-              {...{
-                settings: currentSettings,
-                setCurrentSettings,
-                sectionRef: (el) => (sectionRefs.current.advanced = el),
-              }}
-            />
+        <main className="flex-1 overflow-y-auto bg-secondary">
+          <div className="max-w-3xl mx-auto px-8 py-6 space-y-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-text-main">{activeCategory.label}</h2>
+                <p className="text-xs text-text-secondary">Fine-tune options for this category.</p>
+              </div>
+              <ActiveIcon className="w-6 h-6 text-primary" />
+            </div>
+            <div className="border border-border-color/70 rounded-lg bg-background/60">
+              {renderActiveSection()}
+            </div>
           </div>
         </main>
       </div>
@@ -437,10 +417,9 @@ const SettingsView: React.FC<SettingsViewProps> = ({
 interface SectionProps {
     settings: Settings;
     setCurrentSettings: React.Dispatch<React.SetStateAction<Settings>>;
-    sectionRef: (el: HTMLDivElement | null) => void;
 }
 
-const ProviderSettingsSection: React.FC<SectionProps & { discoveredServices: DiscoveredLLMService[], onDetectServices: () => void, isDetecting: boolean }> = ({ settings, setCurrentSettings, discoveredServices, onDetectServices, isDetecting, sectionRef }) => {
+const ProviderSettingsSection: React.FC<SectionProps & { discoveredServices: DiscoveredLLMService[], onDetectServices: () => void, isDetecting: boolean }> = ({ settings, setCurrentSettings, discoveredServices, onDetectServices, isDetecting }) => {
     const [availableModels, setAvailableModels] = useState<DiscoveredLLMModel[]>([]);
     const [isFetchingModels, setIsFetchingModels] = useState(false);
     const [detectionError, setDetectionError] = useState<string | null>(null);
@@ -495,7 +474,7 @@ const ProviderSettingsSection: React.FC<SectionProps & { discoveredServices: Dis
     const selectedService = discoveredServices.find(s => s.generateUrl === settings.llmProviderUrl);
 
     return (
-        <div id="provider" ref={sectionRef} className="py-6">
+        <div className="py-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">LLM Provider</h2>
             <div className="space-y-6">
                 <SettingRow label="Detect Services" description="Scan for locally running LLM services like Ollama and LM Studio.">
@@ -542,7 +521,7 @@ const ProviderSettingsSection: React.FC<SectionProps & { discoveredServices: Dis
     );
 };
 
-const AppearanceSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurrentSettings' | 'sectionRef'>> = ({ settings, setCurrentSettings, sectionRef }) => {
+const AppearanceSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurrentSettings'>> = ({ settings, setCurrentSettings }) => {
     const CardButton: React.FC<{name: string, value: any, children: React.ReactNode, onClick: (value: any) => void, isSelected: boolean}> = ({ name, value, children, onClick, isSelected }) => (
 
         <button
@@ -569,7 +548,7 @@ const AppearanceSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCu
 
 
     return (
-        <div id="appearance" ref={sectionRef} className="py-6">
+        <div className="py-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">Appearance</h2>
             <div className="space-y-6">
                 <SettingRow label="Interface Scale" description="Adjust the size of all UI elements in the application.">
@@ -868,7 +847,7 @@ interface PythonSectionProps extends SectionProps {
   onValidationChange?: (message: string | null) => void;
 }
 
-const PythonSettingsSection: React.FC<PythonSectionProps> = ({ settings, setCurrentSettings, sectionRef, onValidationChange }) => {
+const PythonSettingsSection: React.FC<PythonSectionProps> = ({ settings, setCurrentSettings, onValidationChange }) => {
   const { addLog } = useLogger();
   const {
     environments,
@@ -1099,7 +1078,7 @@ const PythonSettingsSection: React.FC<PythonSectionProps> = ({ settings, setCurr
   const interpreterValue = formState.useCustomInterpreter ? 'custom' : formState.interpreterPath;
 
   return (
-    <div id="python" ref={sectionRef} className="py-6">
+    <div className="py-6">
       <h2 className="text-lg font-semibold text-text-main mb-4">Python Execution</h2>
       <p className="text-xs text-text-secondary max-w-3xl mb-6">
         Configure how DocForge prepares isolated Python environments. These defaults are applied when auto-creating a virtual
@@ -1368,20 +1347,20 @@ requests"
   );
 };
 
-const GeneralSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurrentSettings' | 'sectionRef'>> = ({ settings, setCurrentSettings, sectionRef }) => {
+const GeneralSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurrentSettings'>> = ({ settings, setCurrentSettings }) => {
     const isOfflineRendererAvailable = typeof window !== 'undefined' && !!window.electronAPI?.renderPlantUML;
     const offlineRendererMessage = 'Offline rendering requires the desktop application with a local Java runtime.';
     return (
-            <div id="general" ref={sectionRef} className="py-6">
+        <div className="py-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">General</h2>
             <div className="space-y-6">
-                 <SettingRow htmlFor="allowPrerelease" label="Receive Pre-releases" description="Get notified about new beta versions and test features early.">
+                <SettingRow htmlFor="allowPrerelease" label="Receive Pre-releases" description="Get notified about new beta versions and test features early.">
                     <ToggleSwitch id="allowPrerelease" checked={settings.allowPrerelease} onChange={(val) => setCurrentSettings(s => ({...s, allowPrerelease: val}))} />
                 </SettingRow>
-                 <SettingRow htmlFor="autoSaveLogs" label="Auto-save Logs" description="Automatically save all logs to a daily file on your computer for debugging.">
+                <SettingRow htmlFor="autoSaveLogs" label="Auto-save Logs" description="Automatically save all logs to a daily file on your computer for debugging.">
                     <ToggleSwitch id="autoSaveLogs" checked={settings.autoSaveLogs} onChange={(val) => setCurrentSettings(s => ({...s, autoSaveLogs: val}))} />
                 </SettingRow>
-                 <SettingRow
+                <SettingRow
                     htmlFor="plantumlRendererMode"
                     label="PlantUML Rendering"
                     description="Choose whether PlantUML diagrams are rendered via the public server or the local renderer."
@@ -1411,7 +1390,7 @@ const GeneralSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurre
     );
 };
 
-const DatabaseSettingsSection: React.FC<{sectionRef: (el: HTMLDivElement | null) => void}> = ({ sectionRef }) => {
+const DatabaseSettingsSection: React.FC = () => {
     const [dbPath, setDbPath] = useState<string>('Loading...');
     const [stats, setStats] = useState<DatabaseStats | null>(null);
     const [isLoadingStats, setIsLoadingStats] = useState(true);
@@ -1561,44 +1540,64 @@ const DatabaseSettingsSection: React.FC<{sectionRef: (el: HTMLDivElement | null)
     };
 
     return (
-         <div id="database" ref={sectionRef} className="py-6">
+        <div className="py-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">Database Management</h2>
             <div className="space-y-6">
                 <SettingRow label="Database File" description="This file contains all your documents, folders, and history.">
-                        <div className="w-full flex flex-col md:flex-row md:items-center gap-2">
-                            <div className="text-sm text-text-main bg-background px-3 py-2 rounded-md border border-border-color w-full font-mono text-xs select-all break-all md:flex-1">
-                                {dbPath}
-                            </div>
-                            <div className="flex items-center gap-2">
-                                <Button onClick={handleCreateDatabase} variant="primary" isLoading={isCreatingDb} disabled={isSwitchingDb || isCreatingDb}>
-                                    <DatabaseIcon className="w-4 h-4 mr-2" /> New Database
-                                </Button>
-                                <Button onClick={handleChangeDatabase} variant="secondary" isLoading={isSwitchingDb} disabled={isSwitchingDb || isCreatingDb}>
-                                    Change Location
-                                </Button>
-                            </div>
+                    <div className="w-full flex flex-col md:flex-row md:items-center gap-2">
+                        <div className="text-sm text-text-main bg-background px-3 py-2 rounded-md border border-border-color w-full font-mono text-xs select-all break-all md:flex-1">
+                            {dbPath}
                         </div>
+                        <div className="flex items-center gap-2">
+                            <Button onClick={handleCreateDatabase} variant="primary" isLoading={isCreatingDb} disabled={isSwitchingDb || isCreatingDb}>
+                                <DatabaseIcon className="w-4 h-4 mr-2" /> New Database
+                            </Button>
+                            <Button onClick={handleChangeDatabase} variant="secondary" isLoading={isSwitchingDb} disabled={isSwitchingDb || isCreatingDb}>
+                                Change Location
+                            </Button>
+                        </div>
+                    </div>
                 </SettingRow>
                 <SettingRow label="Operations" description="Perform maintenance tasks on the application database.">
                     <div className="flex flex-col items-end w-full gap-2">
                         <div className="flex items-center gap-2">
-                            <Button onClick={handleBackup} variant="secondary" isLoading={operation?.name === 'backup' && operation.status === 'running'}><SaveIcon className="w-4 h-4 mr-2" /> Backup</Button>
-                            <Button onClick={handleIntegrityCheck} variant="secondary" isLoading={operation?.name === 'integrity' && operation.status === 'running'}><CheckIcon className="w-4 h-4 mr-2" /> Check Integrity</Button>
-                            <Button onClick={handleVacuum} variant="secondary" isLoading={operation?.name === 'vacuum' && operation.status === 'running'}><SparklesIcon className="w-4 h-4 mr-2" /> Vacuum</Button>
+                            <Button onClick={handleBackup} variant="secondary" isLoading={operation?.name === 'backup' && operation.status === 'running'}>
+                                <SaveIcon className="w-4 h-4 mr-2" /> Backup
+                            </Button>
+                            <Button onClick={handleIntegrityCheck} variant="secondary" isLoading={operation?.name === 'integrity' && operation.status === 'running'}>
+                                <CheckIcon className="w-4 h-4 mr-2" /> Check Integrity
+                            </Button>
+                            <Button onClick={handleVacuum} variant="secondary" isLoading={operation?.name === 'vacuum' && operation.status === 'running'}>
+                                <SparklesIcon className="w-4 h-4 mr-2" /> Vacuum
+                            </Button>
                         </div>
                         {operation && (
-                            <p className={`text-xs mt-2 text-right ${operation.status === 'error' ? 'text-error' : 'text-success'}`}>{operation.message}</p>
+                            <p className={`text-xs mt-2 text-right ${operation.status === 'error' ? 'text-error' : 'text-success'}`}>
+                                {operation.message}
+                            </p>
                         )}
                     </div>
                 </SettingRow>
                 <SettingRow label="Statistics" description="An overview of the database contents and size.">
-                     {isLoadingStats ? <Spinner/> : !stats ? <p className="text-sm text-error">Could not load stats.</p> : (
+                    {isLoadingStats ? (
+                        <Spinner />
+                    ) : !stats ? (
+                        <p className="text-sm text-error">Could not load stats.</p>
+                    ) : (
                         <div className="w-full space-y-4">
                             <div className="grid grid-cols-2 gap-4 text-sm">
-                                <div className="bg-background p-3 rounded-md border border-border-color"><strong>File Size:</strong> {stats.fileSize}</div>
-                                <div className="bg-background p-3 rounded-md border border-border-color"><strong>Schema Version:</strong> {stats.schemaVersion}</div>
-                                <div className="bg-background p-3 rounded-md border border-border-color"><strong>Page Size:</strong> {stats.pageSize} bytes</div>
-                                <div className="bg-background p-3 rounded-md border border-border-color"><strong>Page Count:</strong> {stats.pageCount}</div>
+                                <div className="bg-background p-3 rounded-md border border-border-color">
+                                    <strong>File Size:</strong> {stats.fileSize}
+                                </div>
+                                <div className="bg-background p-3 rounded-md border border-border-color">
+                                    <strong>Schema Version:</strong> {stats.schemaVersion}
+                                </div>
+                                <div className="bg-background p-3 rounded-md border border-border-color">
+                                    <strong>Page Size:</strong> {stats.pageSize} bytes
+                                </div>
+                                <div className="bg-background p-3 rounded-md border border-border-color">
+                                    <strong>Page Count:</strong> {stats.pageCount}
+                                </div>
                             </div>
                             <div className="w-full overflow-hidden border border-border-color rounded-md">
                                 <table className="w-full text-left text-sm">
@@ -1610,25 +1609,27 @@ const DatabaseSettingsSection: React.FC<{sectionRef: (el: HTMLDivElement | null)
                                         </tr>
                                     </thead>
                                     <tbody className="divide-y divide-border-color">
-                                        {stats.tables.map(table => (
+                                        {stats.tables.map((table) => (
                                             <tr key={table.name} className="bg-secondary">
                                                 <td className="p-2 font-mono">{table.name}</td>
                                                 <td className="p-2 font-mono text-right">{table.rowCount}</td>
-                                                <td className="p-2 font-mono text-xs text-text-secondary">{table.indexes.join(', ') || 'none'}</td>
+                                                <td className="p-2 font-mono text-xs text-text-secondary">
+                                                    {table.indexes.join(', ') || 'none'}
+                                                </td>
                                             </tr>
                                         ))}
                                     </tbody>
                                 </table>
                             </div>
                         </div>
-                     )}
+                    )}
                 </SettingRow>
             </div>
         </div>
     );
 };
 
-const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurrentSettings' | 'sectionRef'>> = ({ settings, setCurrentSettings, sectionRef }) => {
+const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurrentSettings'>> = ({ settings, setCurrentSettings }) => {
     const { addLog } = useLogger();
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const [jsonString, setJsonString] = useState(() => JSON.stringify(settings, null, 2));
@@ -1764,14 +1765,18 @@ const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurr
     }, [addLog, applyImportedSettings]);
 
     return (
-         <div id="advanced" ref={sectionRef} className="py-6">
+        <div className="py-6">
             <h2 className="text-lg font-semibold text-text-main mb-4">Advanced</h2>
             <div className="space-y-6">
                 <SettingRow label="Settings Transfer" description="Export the current configuration or import it from a JSON file.">
                     <div className="flex flex-col gap-3">
                         <div className="flex flex-wrap gap-2">
-                            <Button onClick={handleExport} variant="secondary" size="sm">Export Settings</Button>
-                            <Button onClick={handleImport} variant="secondary" size="sm">Import Settings</Button>
+                            <Button onClick={handleExport} variant="secondary" size="sm">
+                                Export Settings
+                            </Button>
+                            <Button onClick={handleImport} variant="secondary" size="sm">
+                                Import Settings
+                            </Button>
                         </div>
                         {transferStatus && (
                             <p className={`text-xs ${transferStatus.type === 'success' ? 'text-success' : 'text-error'}`}>
@@ -1791,10 +1796,16 @@ const AdvancedSettingsSection: React.FC<Pick<SectionProps, 'settings' | 'setCurr
                     <div className="w-full">
                         <div className="flex justify-end mb-2">
                             <div className="flex items-center p-1 bg-background rounded-lg border border-border-color">
-                                <button onClick={() => setMode('tree')} className={`px-3 py-1 text-xs font-semibold rounded-md transition-colors ${mode === 'tree' ? 'bg-secondary text-primary' : 'text-text-secondary hover:bg-border-color/50'}`}>
+                                <button
+                                    onClick={() => setMode('tree')}
+                                    className={`px-3 py-1 text-xs font-semibold rounded-md transition-colors ${mode === 'tree' ? 'bg-secondary text-primary' : 'text-text-secondary hover:bg-border-color/50'}`}
+                                >
                                     Tree
                                 </button>
-                                <button onClick={() => setMode('json')} className={`px-3 py-1 text-xs font-semibold rounded-md transition-colors ${mode === 'json' ? 'bg-secondary text-primary' : 'text-text-secondary hover:bg-border-color/50'}`}>
+                                <button
+                                    onClick={() => setMode('json')}
+                                    className={`px-3 py-1 text-xs font-semibold rounded-md transition-colors ${mode === 'json' ? 'bg-secondary text-primary' : 'text-text-secondary hover:bg-border-color/50'}`}
+                                >
                                     JSON
                                 </button>
                             </div>


### PR DESCRIPTION
## Summary
- refactor the settings view to show a single category at a time with contextual header content
- simplify each settings section and the keyboard shortcuts panel to work without scroll-linked DOM refs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e67ce142748332bbaaf478bfe5c128